### PR TITLE
Plan 19: player_rankings Endpoint + CORS für die externe SPA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,3 +181,5 @@ gem 'rtesseract', '~> 3.1'
 
 # Cron job management for scheduled tasks
 gem 'whenever', require: false
+
+gem "rack-cors", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,6 +558,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (3.1.18)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-session (2.1.1)
@@ -872,6 +874,7 @@ DEPENDENCIES
   pretender (~> 0.4)
   puma (~> 6.6)
   pundit (~> 2.1)
+  rack-cors (~> 2.0)
   rack-mini-profiler
   rails (~> 7.2.2)
   rails-i18n

--- a/app/controllers/api/external_tournaments_controller.rb
+++ b/app/controllers/api/external_tournaments_controller.rb
@@ -250,6 +250,47 @@ module Api
       render json: {error: e.message}, status: :not_found
     end
 
+    # GET /api/external_tournament/player_rankings?region=NBV&discipline=Dreiband+klein
+    #     &player_cc_ids=11,12,13  (optional; ohne Filter: gesamte Rangliste)
+    #     &season=2024/2025        (optional; Default: juengste Saison mit Rankings)
+    #
+    # Plan 19-01: Sortiert eine Spielerliste nach dem offiziellen PlayerRanking
+    # einer Disziplin (bestes Ranking zuerst) — Substrat fuer Ranking-Setzlisten
+    # in der App (z. B. Doppel-KO). Region-scoped, read-only.
+    # Response: carambus.player_rankings/v1
+    #   { schema, region:{shortname}, season:{name}, discipline:{name},
+    #     players:[{cc_id,firstname,lastname,dbu_nr,rank,gd,hs,balls,innings}],
+    #     unranked:[cc_id,...] }
+    # Errors: 401 (Auth) / 404 (Region | Disziplin unbekannt) / 422 (discipline fehlt)
+    def player_rankings
+      region = Region.find_by!(shortname: params[:region].to_s.upcase)
+      if params[:discipline].blank?
+        return render json: {error: "discipline is required"}, status: :unprocessable_entity
+      end
+
+      cc_ids = params[:player_cc_ids].to_s.split(",").map(&:strip).reject(&:blank?)
+      result = ExternalTournament::RankingQuery.players(
+        region: region,
+        discipline_name: params[:discipline],
+        player_cc_ids: cc_ids,
+        season_name: params[:season]
+      )
+      if result.nil?
+        return render json: {error: "Discipline not found: #{params[:discipline]}"}, status: :not_found
+      end
+
+      render json: {
+        schema: "carambus.player_rankings/v1",
+        region: {shortname: region.shortname},
+        season: {name: result.season&.name},
+        discipline: {name: result.discipline.name},
+        players: result.ranked,
+        unranked: result.unranked
+      }
+    rescue ActiveRecord::RecordNotFound => e
+      render json: {error: e.message}, status: :not_found
+    end
+
     # POST /api/external_tournament/tournament
     #
     # Plan 17-02: Legt ein lokales App-Turnier OHNE TournamentPlan/Executor an (D-17-vision-1).

--- a/app/services/external_tournament/ranking_query.rb
+++ b/app/services/external_tournament/ranking_query.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module ExternalTournament
+  # Plan 19-01 (Ranking-Setzliste): read-only, region-scoped Sortierung einer
+  # Spielerliste nach dem offiziellen PlayerRanking einer Disziplin.
+  #
+  # Genutzt von der externen App (Doppel-KO u. a.), um aus ausgewaehlten Spielern
+  # eine Setzliste zu erzeugen: bestes Ranking = Setzplatz 1.
+  #
+  #   players(region:, discipline_name:, player_cc_ids:)
+  #     -> { season:, discipline:, ranked:[...], unranked:[cc_id,...] }
+  #
+  # Reine Reads, keine Seiteneffekte.
+  #
+  # Disziplin-Aufloesung (D-19-01-A): exakter Name, sonst Synonym-Treffer
+  # (Discipline#synonyms ist newline-separiert und enthaelt den Namen selbst).
+  # Mehrere Disziplinen gleichen Namens (verschiedene table_kinds) werden als
+  # Kandidaten-Menge behandelt.
+  #
+  # Saison (D-19-01-B): per Default die juengste Saison, fuer die ueberhaupt
+  # Rankings dieser Disziplin+Region existieren (Rankings hinken der laufenden
+  # Saison oft hinterher). Optional per season_name uebersteuerbar.
+  class RankingQuery
+    Result = Struct.new(:season, :discipline, :ranked, :unranked, keyword_init: true)
+
+    def self.find_disciplines(name)
+      return [] if name.blank?
+      target = name.to_s.strip
+      exact = Discipline.where(name: target).to_a
+      return exact if exact.any?
+      Discipline.where("synonyms ILIKE ?", "%#{target}%").select do |d|
+        d.synonyms.to_s.split("\n").map(&:strip).include?(target)
+      end
+    end
+
+    # Liefert die zu verwendende Saison (juengste mit Rankings) oder nil.
+    def self.resolve_season(region:, discipline_ids:, season_name: nil)
+      if season_name.present?
+        return Season.find_by(name: season_name)
+      end
+      sid = PlayerRanking
+        .where(region_id: region.id, discipline_id: discipline_ids)
+        .order(season_id: :desc)
+        .limit(1)
+        .pick(:season_id)
+      sid ? Season.find_by(id: sid) : Season.current_season
+    end
+
+    def self.players(region:, discipline_name:, player_cc_ids: [], season_name: nil)
+      disciplines = find_disciplines(discipline_name)
+      return nil if disciplines.empty?
+      discipline_ids = disciplines.map(&:id)
+      season = resolve_season(region: region, discipline_ids: discipline_ids, season_name: season_name)
+
+      scope = PlayerRanking
+        .where(region_id: region.id, discipline_id: discipline_ids)
+        .includes(:player)
+      scope = scope.where(season_id: season.id) if season
+
+      cc_filter = Array(player_cc_ids).map(&:to_s).reject(&:blank?)
+      by_cc = {}
+      scope.each do |r|
+        p = r.player
+        next if p.nil?
+        next if cc_filter.any? && !cc_filter.include?(p.cc_id.to_s)
+        # Pro Spieler nur den besten (kleinsten) Rang behalten, falls mehrere
+        # Kandidaten-Disziplinen denselben Spieler liefern.
+        existing = by_cc[p.cc_id]
+        by_cc[p.cc_id] = r if existing.nil? || (r.rank || 1 << 30) < (existing.rank || 1 << 30)
+      end
+
+      ranked = by_cc.values
+        .sort_by { |r| [r.rank || (1 << 30), -(r.gd || -1e9)] }
+        .map { |r| serialize(r) }
+
+      ranked_cc = ranked.map { |h| h[:cc_id].to_s }
+      unranked = cc_filter.reject { |cc| ranked_cc.include?(cc) }
+
+      Result.new(
+        season: season,
+        discipline: disciplines.first,
+        ranked: ranked,
+        unranked: unranked
+      )
+    end
+
+    def self.serialize(r)
+      p = r.player
+      {
+        cc_id: p.cc_id,
+        firstname: p.firstname,
+        lastname: p.lastname,
+        dbu_nr: p.dbu_nr&.to_s,
+        rank: r.rank,
+        gd: r.gd,
+        hs: r.hs,
+        balls: r.balls,
+        innings: r.innings
+      }
+    end
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Plan 19-02: CORS fuer die externe Turnier-SPA.
+#
+# Die App (Multi-Schema-Turnier-App, eigenes Repo) wird ueber einen statischen
+# Webserver ausgeliefert (ES-Module brauchen http://) und ist damit eine ANDERE
+# Origin als der Carambus-Server. Ohne CORS-Header blockt der Browser die
+# Cross-Origin-Aufrufe an /login + /api/external_tournament/*.
+#
+# Scope bewusst eng:
+#   - nur /login + /api/external_tournament/* (NICHT die ganze App)
+#   - Default-Origins: localhost + private LAN-Bereiche (RFC1918).
+#     Per ENV uebersteuerbar: EXTERNAL_APP_CORS_ORIGINS="https://app.example,http://host:8123"
+#   - credentials NICHT noetig (Auth ueber Bearer-Token im Header, kein Cookie).
+#   - WICHTIG: Authorization-Response-Header MUSS exposed werden — die App liest
+#     den JWT nach POST /login aus genau diesem Header. Cross-Origin ist er sonst
+#     unsichtbar.
+#
+# Sicherheit: oeffnet ausschliesslich die externe Turnier-Bridge-API (devise-jwt
+# authentifiziert) fuer LAN-Clients. Keine Cookies/Session betroffen.
+
+LAN_ORIGIN_PATTERN = %r{
+  \Ahttps?://(
+    localhost |
+    127\.0\.0\.1 |
+    192\.168\.\d{1,3}\.\d{1,3} |
+    10\.\d{1,3}\.\d{1,3}\.\d{1,3} |
+    172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}
+  )(:\d+)?\z
+}x
+
+env_origins = ENV.fetch("EXTERNAL_APP_CORS_ORIGINS", "")
+                 .split(",").map(&:strip).reject(&:empty?)
+allowed_origins = env_origins.presence || [LAN_ORIGIN_PATTERN]
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins(*allowed_origins)
+
+    resource "/api/external_tournament/*",
+      headers: :any,
+      methods: %i[get post options],
+      expose: ["Authorization"],
+      max_age: 600
+
+    resource "/login",
+      headers: :any,
+      methods: %i[post options],
+      expose: ["Authorization"],
+      max_age: 600
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,11 @@ Rails.application.routes.draw do
     get "external_tournament/club_players",
         to: "external_tournaments#club_players",
         as: :external_tournament_club_players
+    # Plan 19-01 (Ranking-Setzliste): Spielerliste nach Disziplin-Ranking sortiert
+    # (bestes Ranking = Setzplatz 1) fuer App-Setzlisten wie Doppel-KO.
+    get "external_tournament/player_rankings",
+        to: "external_tournaments#player_rankings",
+        as: :external_tournament_player_rankings
   end
 
   # Debug routes (development only)

--- a/test/controllers/api/external_tournaments_rankings_test.rb
+++ b/test/controllers/api/external_tournaments_rankings_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Plan 19-01: Controller-Tests fuer den Ranking-Setzlisten-Endpoint
+#   GET /api/external_tournament/player_rankings -> carambus.player_rankings/v1
+# Auth-Muster (Service-User + JWT) wie die uebrigen external_tournament-Tests.
+module Api
+  class ExternalTournamentsRankingsTest < ActionDispatch::IntegrationTest
+    setup do
+      @nbv = regions(:nbv)
+      @service_user = User.create!(email: "test-2band-ranking@carambus.de", password: "password123")
+      @season = Season.create!(name: "RANK-CTRL-2099/2100")
+      @discipline = Discipline.create!(name: "Test19 Dreiband klein")
+
+      @p1 = mk_player("One", 190_201, 96_001)   # Rang 1
+      @p2 = mk_player("Two", 190_202, 96_002)   # Rang 2
+      @p3 = mk_player("Three", 190_203, 96_003) # Rang 3
+      @p_norank = mk_player("Nor", 190_204, 96_004) # kein Ranking
+
+      mk_rank(@p2, rank: 2, gd: 1.500)
+      mk_rank(@p1, rank: 1, gd: 2.250)
+      mk_rank(@p3, rank: 3, gd: 0.900)
+    end
+
+    teardown do
+      PlayerRanking.where(season_id: @season&.id).delete_all
+      Player.where("firstname LIKE ?", "Test19R-%").delete_all
+      @discipline&.destroy
+      @season&.destroy
+      User.where(email: "test-2band-ranking@carambus.de").delete_all
+    end
+
+    test "player_rankings returns players sorted by rank with schema" do
+      jwt = login_jwt
+      get "/api/external_tournament/player_rankings?region=NBV&discipline=#{CGI.escape(@discipline.name)}",
+        headers: auth_headers(jwt)
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal "carambus.player_rankings/v1", body["schema"]
+      assert_equal "NBV", body.dig("region", "shortname")
+      assert_equal @discipline.name, body.dig("discipline", "name")
+      ccids = body["players"].map { |p| p["cc_id"] }
+      assert_equal [190_201, 190_202, 190_203], ccids, "nach Rang sortiert (1,2,3)"
+      assert_equal 1, body["players"].first["rank"]
+      assert_equal "96001", body["players"].first["dbu_nr"]
+      assert_in_delta 2.250, body["players"].first["gd"], 0.001
+    end
+
+    test "player_rankings filters by player_cc_ids and reports unranked" do
+      jwt = login_jwt
+      get "/api/external_tournament/player_rankings?region=NBV&discipline=#{CGI.escape(@discipline.name)}" \
+          "&player_cc_ids=190203,190201,190204",
+        headers: auth_headers(jwt)
+      assert_response :success
+      body = JSON.parse(response.body)
+      ccids = body["players"].map { |p| p["cc_id"] }
+      assert_equal [190_201, 190_203], ccids, "nur angeforderte, nach Rang sortiert"
+      assert_equal ["190204"], body["unranked"], "ohne Ranking → unranked"
+    end
+
+    test "player_rankings resolves discipline via synonym" do
+      @discipline.update!(synonyms: "Dreiband-Synonym19")
+      jwt = login_jwt
+      get "/api/external_tournament/player_rankings?region=NBV&discipline=Dreiband-Synonym19",
+        headers: auth_headers(jwt)
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal @discipline.name, body.dig("discipline", "name")
+    end
+
+    test "player_rankings without discipline returns 422" do
+      jwt = login_jwt
+      get "/api/external_tournament/player_rankings?region=NBV", headers: auth_headers(jwt)
+      assert_response :unprocessable_entity
+    end
+
+    test "player_rankings with unknown discipline returns 404" do
+      jwt = login_jwt
+      get "/api/external_tournament/player_rankings?region=NBV&discipline=GibtsNicht19",
+        headers: auth_headers(jwt)
+      assert_response :not_found
+    end
+
+    test "player_rankings with unknown region returns 404" do
+      jwt = login_jwt
+      get "/api/external_tournament/player_rankings?region=ZZZ&discipline=#{CGI.escape(@discipline.name)}",
+        headers: auth_headers(jwt)
+      assert_response :not_found
+    end
+
+    test "player_rankings without auth returns 401" do
+      get "/api/external_tournament/player_rankings?region=NBV&discipline=x", headers: auth_headers(nil)
+      assert_response :unauthorized
+    end
+
+    private
+
+    def mk_player(suffix, cc_id, dbu_nr)
+      Player.create!(firstname: "Test19R-#{suffix}", lastname: "Rank#{suffix}",
+        region_id: @nbv.id, cc_id: cc_id, dbu_nr: dbu_nr)
+    end
+
+    def mk_rank(player, rank:, gd:)
+      PlayerRanking.create!(player: player, region: @nbv, season: @season,
+        discipline: @discipline, rank: rank, gd: gd)
+    end
+
+    def auth_headers(jwt)
+      h = {"Content-Type" => "application/json", "Accept" => "application/json"}
+      h["Authorization"] = "Bearer #{jwt}" if jwt
+      h
+    end
+
+    def login_jwt
+      post "/login",
+        params: {user: {email: @service_user.email, password: "password123"}}.to_json,
+        headers: {"Content-Type" => "application/json", "Accept" => "application/json"}
+      raise "Login failed in test: #{response.code} #{response.body}" unless response.successful?
+      jwt = response.headers["Authorization"].to_s.sub(/\ABearer\s+/, "")
+      cookies.delete(:_carambus_session) if cookies.respond_to?(:delete)
+      reset!
+      jwt
+    end
+  end
+end


### PR DESCRIPTION
## Überblick

Zwei Bausteine, damit die externe Multi-Schema-Turnier-App (u. a. Doppel-KO) gegen diese Carambus-Instanz arbeiten kann.

### 1) Ranking-Setzliste (Plan 19-01)

Neuer read-only Endpoint **`GET /api/external_tournament/player_rankings`** → `carambus.player_rankings/v1`. Sortiert eine Spielerliste nach dem offiziellen `PlayerRanking` einer Disziplin (bestes Ranking = Setzplatz 1).

```
GET /api/external_tournament/player_rankings?region=NBV&discipline=Dreiband+klein
    [&player_cc_ids=11683,10024,10587]   # optional Filter
    [&season=2024/2025]                  # optional, Default jüngste Saison mit Rankings
```

- `ExternalTournament::RankingQuery` (read-only, region-scoped); Disziplin per Name/Synonym; Saison-Default = jüngste mit Rankings; `player_cc_ids`-Filter; ohne Ranking → `unranked[]`.
- Controller-Action + Route + Controller-Test.
- ✅ Read-only-Smoke gegen Dev-DB grün. ⚠ Controller-Test bitte in Test-/CI-Umgebung ausführen (lokaler Checkout ohne `test`-DB).

### 2) CORS für die externe SPA (Plan 19-02)

Die App läuft über einen statischen Webserver (ES-Module → `http://`) und ist damit eine **andere Origin** als der Carambus-Server → Browser blockt die API-Calls. Fix mit `rack-cors`:

- `config/initializers/cors.rb`: nur `/login` + `/api/external_tournament/*`.
- Default-Origins: localhost + RFC1918-LAN; override via `EXTERNAL_APP_CORS_ORIGINS`.
- `credentials` off (Bearer-Token, kein Cookie); **`Authorization`-Response-Header exposed** (App liest den JWT nach Login daraus — cross-origin sonst unsichtbar).
- ✅ Verifiziert (Rack::MockRequest-Preflight): LAN/localhost erlaubt, Fremd-Origin blockiert (ACAO nil), Expose-Header=`Authorization`.

## Deploy

Nach grünem Test: `:3008` → `:3131` (`smtp_guard`-Workaround beachten). Danach kann die SPA live angebunden werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)