### PR TITLE
CC-lose Turnierverwaltung: Anlage, Meldeliste, Saison-Vorlage, Meldelisten-Ingest

### DIFF
--- a/app/controllers/api/entry_lists_controller.rb
+++ b/app/controllers/api/entry_lists_controller.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Api
+  # Plan 28-01: Liefert die MELDELISTE einer Region/Saison als JSON aus.
+  #
+  # Laeuft auf dem REGION SERVER, wo der Sportwart die Meldungen pflegt (Phase 26). Die AUTHORITY
+  # holt sich das Dokument ab (Pull, analog CC-Scrape) und legt daraus globale Records an —
+  # die lokalen IDs dieser Instanz werden dabei uebersetzt (RegionServer::EntryListImporter).
+  #
+  # Abgrenzung Meldeliste vs. Teilnehmerliste: Die Meldeliste sagt, WER GEMELDET ist; die
+  # Teilnehmerliste entsteht spaeter auf dem Location Server aus den global eingetroffenen Seedings
+  # (`use_clubcloud_as_participants`, id < MIN_ID -> id >= MIN_ID). Dieser Endpunkt liefert nur die
+  # Meldung — keine Ergebnisse, keine Spiele.
+  #
+  # Auth: devise-jwt + Service-Account je Region (Muster aus ExternalTournamentsController).
+  class EntryListsController < ApplicationController
+    before_action :authenticate_user!
+    skip_forgery_protection
+
+    # GET /api/entry_lists?region=NBV&season=2026/2027
+    #
+    # Response (200):
+    #   { "schema": "carambus.entry_list/v1",
+    #     "region": {"shortname": "NBV"},
+    #     "season": {"name": "2026/2027"},
+    #     "tournaments": [ {..., "entries": [{"dbu_nr":…, "lastname":…, "firstname":…, "club":…}] } ] }
+    #
+    # Errors: 401 (Auth) / 404 (Region oder Saison unbekannt)
+    def index
+      region = Region.find_by("UPPER(shortname) = ?", params[:region].to_s.upcase)
+      return render(json: {error: "Region not found"}, status: :not_found) if region.nil?
+
+      season = Season.find_by(name: params[:season].to_s)
+      return render(json: {error: "Season not found"}, status: :not_found) if season.nil?
+
+      render json: {
+        schema: "carambus.entry_list/v1",
+        region: {shortname: region.shortname},
+        season: {name: season.name},
+        tournaments: tournaments_for(region, season).map { |t| tournament_payload(t) }
+      }
+    end
+
+    private
+
+    # Einzelmeisterschaften dieser Region/Saison — OHNE Entwuerfe: eine Saison-Kopie (Plan 27-01)
+    # ist noch nicht vom Sportwart freigegeben und darf nicht global werden.
+    def tournaments_for(region, season)
+      ::Tournament
+        .where(season_id: season.id, organizer_type: "Region", organizer_id: region.id)
+        .without_drafts
+        .order(:date)
+    end
+
+    def tournament_payload(tournament)
+      attrs = tournament.attributes.slice(*::Tournament::SeasonCopier::STRUCTURE_ATTRIBUTES)
+
+      attrs.merge(
+        # Stabile Quell-Kennung: daraus baut die Authority ihr source_url-Keying. Die lokale ID ist
+        # NUR hier sichtbar — auf der Authority entsteht eine eigene globale ID.
+        "source_tournament_id" => tournament.id,
+        "date" => tournament.date,
+        "end_date" => tournament.end_date,
+        "entries" => entries_for(tournament)
+      )
+    end
+
+    # Gemeldete Spieler. dbu_nr ist der Aufloesungsschluessel auf der Authority (global eindeutig);
+    # Name und Verein reisen als Gegenprobe mit, damit unaufloesbare Meldungen benennbar sind.
+    def entries_for(tournament)
+      seedings = tournament.seedings.includes(:player).order(:position)
+
+      seedings.filter_map do |seeding|
+        player = seeding.player
+        next if player.nil?
+
+        {
+          "dbu_nr" => player.dbu_nr,
+          "lastname" => player.lastname,
+          "firstname" => player.firstname,
+          "club" => club_name_for(player, tournament),
+          "position" => seeding.position,
+          "balls_goal" => seeding.balls_goal
+        }
+      end
+    end
+
+    def club_name_for(player, tournament)
+      ::SeasonParticipation
+        .where(player_id: player.id, season_id: tournament.season_id)
+        .includes(:club).first&.club&.name
+    end
+  end
+end

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -500,7 +500,11 @@ class TournamentsController < ApplicationController
 
   # GET /tournaments/new
   def new
-    @tournament = Tournament.new
+    # Phase 25-01: Vorbelegung von season/organizer — ohne beide schlaegt #create still fehl
+    # (belongs_to :season und :organizer sind nicht optional). Region aus Carambus.config.context
+    # wie in Admin::UserFormHelper#server_region (region-agnostisch, kein hartes Shortname).
+    @season = Season.current_season
+    @tournament = Tournament.new(season: @season, organizer: server_region_for_new)
   end
 
   # GET /tournaments/1/edit
@@ -518,10 +522,16 @@ class TournamentsController < ApplicationController
     else
       @tournament.single_or_league = "single"
     end
+    # Phase 25-01: CC-lose Neuanlage — kein automatischer CC-Upload. Nur im create-Pfad,
+    # der Spalten-Default bleibt unberuehrt (Setter schreibt bei new_record? direkt ins Attribut).
+    @tournament.auto_upload_to_cc = false
+
     if @tournament.save
       redirect_to @tournament, notice: "Tournament was successfully created."
     else
-      redirect_back(fallback_location: tournaments_path)
+      # Fehler sichtbar machen statt still zurueckzuleiten (redirect_back verwarf sie).
+      @season = @tournament.season || Season.current_season
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -1168,7 +1178,19 @@ class TournamentsController < ApplicationController
                                        :handicap_tournier, :league_id, :organizer_id, :organizer_type, :manual_assignment, :continuous_placements,
                                        :sets_to_win, :sets_to_play, :team_size, :kickoff_switches_with, :fixed_display_left,
                                        :color_remains_with_set, :allow_overflow, :allow_follow_up,
-                                       :turnier_leiter_user_id)
+                                       :turnier_leiter_user_id, :source_url)
+  end
+
+  # Phase 25-01: Server-Region aus der Scenario-Config (Carambus.config.context) fuer die
+  # Organizer-Vorbelegung bei Neuanlage. Muster aus Admin::UserFormHelper#server_region.
+  # nil, wenn kein Kontext gesetzt ist — dann muss der Organizer im Formular gewaehlt werden.
+  def server_region_for_new
+    ctx = (Carambus.config.context.to_s if Carambus.config.respond_to?(:context))
+    return nil if ctx.blank?
+
+    Region.find_by("UPPER(shortname) = ?", ctx.upcase)
+  rescue
+    nil
   end
 
   # Stellt sicher, dass Turniermanagement nur auf lokalen Servern möglich ist

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -38,6 +38,13 @@ class TournamentsController < ApplicationController
 
     results = SearchService.call(Tournament.search_hash(search_params))
 
+    # Plan 27-01: Entwuerfe aus der Saison-Kopie sind standardmaessig ausgeblendet — sie tragen ein
+    # geschaetztes Datum und sind noch nicht vom Sportwart geprueft. `?drafts=1` macht sie sichtbar,
+    # damit sie nach einem Kopier-Lauf auffindbar bleiben. Der Filter greift VOR dem H19-Block,
+    # damit „Demnächst" dieselbe Menge sieht.
+    @show_drafts = params[:drafts].present?
+    results = @show_drafts ? results.drafts : results.without_drafts
+
     # H19: „Demnächst"-Block — anstehende Turniere (nächste 14 Tage) im Standard-Blick
     # oben abgesetzt, aus der datum-absteigenden Hauptliste ausgeklammert.
     @show_upcoming = false

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -565,7 +565,14 @@ class TournamentsController < ApplicationController
       render :edit
     end
   rescue StandardError => e
-    Rails.logger.info "#{e} #{e.backtrace.join("\n")}"
+    # Vorher wurde hier nur geloggt — ohne Render/Redirect antwortete Rails mit
+    # 204 No Content, das Update war fuer den Nutzer stillschweigend verschwunden.
+    Rails.logger.error "#{e} #{e.backtrace.join("\n")}"
+    raise if performed? # Fehler nach dem Rendern — nicht noch einmal rendern
+
+    flash.now[:alert] = I18n.t("tournaments.errors.update_failed",
+      default: "Aktualisierung fehlgeschlagen: %{message}", message: e.message)
+    render :edit, status: :unprocessable_entity
   end
 
   # DELETE /tournaments/1

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -7,7 +7,7 @@ class TournamentsController < ApplicationController
                 only: %i[show edit update destroy order_by_ranking_or_handicap finish_seeding edit_games reload_from_cc new_team
                          finalize_modus select_modus tournament_monitor reset start define_participants add_team placement
                          upload_invitation parse_invitation apply_seeding_order compare_seedings add_player_by_dbu
-                         use_clubcloud_as_participants update_seeding_position
+                         use_clubcloud_as_participants update_seeding_position players_by_club
                          recalculate_groups test_tournament_status_update]
   before_action :ensure_rankings_cached, only: %i[show]
   before_action :load_clubcloud_seedings, only: %i[show]
@@ -16,7 +16,7 @@ class TournamentsController < ApplicationController
                                                finalize_modus select_modus reset start define_participants add_team
                                                upload_invitation parse_invitation apply_seeding_order compare_seedings
                                                add_player_by_dbu use_clubcloud_as_participants update_seeding_position
-                                               recalculate_groups]
+                                               players_by_club recalculate_groups]
 
   # UI-07 D-18 / Phase 39 D-12: Felder, die vor dem Turnierstart gegen
   # Discipline#parameter_ranges geprüft werden. Reihenfolge matcht die
@@ -880,6 +880,41 @@ class TournamentsController < ApplicationController
                 message_type => messages.join(' | ')
   end
 
+  # GET /tournaments/:id/players_by_club?club_id=N (JSON)
+  #
+  # Plan 26-01: speist die Club->Spieler-Kaskade der Meldeliste. Liefert die Spieler eines Vereins
+  # aus der laufenden Saison, OHNE die bereits gemeldeten — die `dbu_nr` im Payload traegt die
+  # Uebernahme in den bestehenden add_player_by_dbu-Pfad.
+  #
+  # Abgrenzung zu Admin::UsersController#players_by_club: der ist `system_admin?`-only und damit
+  # fuer Sportwarte nicht nutzbar. Schutz hier = `ensure_local_server` wie bei define_participants.
+  def players_by_club
+    club_id = params[:club_id]
+    return render(json: []) if club_id.blank?
+
+    already_seeded = @tournament.seedings.where(entry_list_seeding_scope).pluck(:player_id).compact.to_set
+
+    # Saison des TURNIERS, nicht die laufende: Meldungen gehoeren zur Turniersaison. Bei einem
+    # Turnier der Vorsaison zeigte `Season.current_season` sonst die falschen Spieler — und sie
+    # ist nicht immer gesetzt (in der Testumgebung nil, wenn die Saison noch nicht angelegt ist).
+    season_id = @tournament.season_id || Season.current_season&.id
+
+    rows = SeasonParticipation
+      .where(club_id: club_id, season_id: season_id)
+      .includes(:player)
+      .filter_map do |sp|
+        player = sp.player
+        next if player.nil? || player.fullname.blank?
+        next if already_seeded.include?(player.id)
+
+        {id: player.id, label: player.fullname, dbu_nr: player.dbu_nr}
+      end
+      .uniq { |h| h[:id] }
+      .sort_by { |h| h[:label].to_s }
+
+    render json: rows
+  end
+
   # POST /tournaments/:id/apply_seeding_order
   def apply_seeding_order
     seeding_order = params[:seeding_order] # Array von Player IDs in Reihenfolge
@@ -1179,6 +1214,17 @@ class TournamentsController < ApplicationController
                                        :sets_to_win, :sets_to_play, :team_size, :kickoff_switches_with, :fixed_display_left,
                                        :color_remains_with_set, :allow_overflow, :allow_follow_up,
                                        :turnier_leiter_user_id, :source_url)
+  end
+
+  # Plan 26-01: aktiver Seeding-Scope des Turniers — lokale Seedings haben Vorrang, sonst die
+  # globalen. Spiegelt bewusst die Logik aus add_player_by_dbu (dort inline), damit beide Pfade
+  # dasselbe "bereits gemeldet" verstehen; Konsolidierung gehoert in den Flow von Phase 28.
+  def entry_list_seeding_scope
+    if @tournament.seedings.where("seedings.id >= #{Seeding::MIN_ID}").any?
+      "seedings.id >= #{Seeding::MIN_ID}"
+    else
+      "seedings.id < #{Seeding::MIN_ID}"
+    end
   end
 
   # Phase 25-01: Server-Region aus der Scenario-Config (Carambus.config.context) fuer die

--- a/app/helpers/tournaments_helper.rb
+++ b/app/helpers/tournaments_helper.rb
@@ -66,4 +66,41 @@ module TournamentsHelper
   def tournament_director?(user)
     user&.club_admin? || user&.system_admin?
   end
+
+  # Plan 26-01: Vereinsauswahl für die Meldeliste eines Region-Turniers.
+  #
+  # Liefert [[label, id], ...] für ein select — Vereine der ausrichtenden Region, "die wichtigsten
+  # zuerst", ohne neue Datenhaltung und ohne Konfiguration:
+  #   1. Vereine, aus denen bereits Teilnehmer DIESES Turniers gemeldet sind (wächst mit der Meldung)
+  #   2. Verein(e) des Austragungsorts
+  #   3. alle übrigen alphabetisch
+  # Ist keine Region bestimmbar, bleibt die Liste leer — der Helfer errät nichts.
+  def entry_list_clubs_for(tournament)
+    region = tournament.region || (tournament.organizer if tournament.organizer.is_a?(Region))
+    return [] if region.blank?
+
+    clubs = Club.where(region_id: region.id).order(:name).to_a
+    return [] if clubs.empty?
+
+    # Vereinszugehörigkeit über SeasonParticipation der TURNIERSAISON — dieselbe Quelle wie
+    # TournamentsController#players_by_club. (Player hat zwar eine club_id-Spalte, aber kein
+    # belongs_to :club; maßgeblich ist season_participations.club_id.)
+    seeded_player_ids = tournament.seedings.pluck(:player_id).compact
+    seeded_club_ids = if seeded_player_ids.any?
+      SeasonParticipation
+        .where(player_id: seeded_player_ids, season_id: tournament.season_id)
+        .pluck(:club_id).compact.to_set
+    else
+      Set.new
+    end
+    # Location hat KEIN belongs_to :club (club_id ist ignored_column) — der Bezug läuft über
+    # club_locations, es können mehrere Vereine an einem Spielort sein.
+    location_club_ids = Array(tournament.location&.clubs&.map(&:id)).to_set
+
+    ranked, rest = clubs.partition { |c| seeded_club_ids.include?(c.id) || location_club_ids.include?(c.id) }
+    # Innerhalb der Vorauswahl: Vereine mit Meldungen vor reinen Austragungsort-Vereinen.
+    ranked.sort_by! { |c| [seeded_club_ids.include?(c.id) ? 0 : 1, c.name.to_s] }
+
+    ranked.map { |c| [c.name, c.id] } + rest.map { |c| [c.name, c.id] }
+  end
 end

--- a/app/javascript/controllers/dependent_select_controller.js
+++ b/app/javascript/controllers/dependent_select_controller.js
@@ -5,7 +5,14 @@ import { Controller } from "@hotwired/stimulus"
 // Eine bestehende Auswahl (verknuepfter Spieler) bleibt erhalten, falls weiterhin in der Liste.
 export default class extends Controller {
   static targets = ["source", "dest"]
-  static values = { url: String, placeholder: { type: String, default: "— Spieler wählen —" } }
+  // Plan 26-01: valueKey erlaubt es, ein anderes Feld als `id` als option-value zu nutzen
+  // (Meldeliste: `dbu_nr`, damit das Select direkt das add_player_by_dbu-Formular speist).
+  // Default "id" = bisheriges Verhalten — der Admin-Konsument bleibt unberührt.
+  static values = {
+    url: String,
+    placeholder: { type: String, default: "— Spieler wählen —" },
+    valueKey: { type: String, default: "id" }
+  }
 
   connect() {
     // Bei bereits vorausgewaehltem Verein die volle Spielerliste laden (verknuepfter
@@ -41,9 +48,10 @@ export default class extends Controller {
     this.resetDest()
     players.forEach((p) => {
       const opt = document.createElement("option")
-      opt.value = p.id
+      const value = p[this.valueKeyValue] ?? p.id
+      opt.value = value
       opt.textContent = p.label
-      if (String(p.id) === String(previous)) opt.selected = true
+      if (String(value) === String(previous)) opt.selected = true
       this.destTarget.appendChild(opt)
     })
   }

--- a/app/models/concerns/scrape_list_guard.rb
+++ b/app/models/concerns/scrape_list_guard.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Fail-silent-Wächter für Scrape-Listen (Befund 2026-07-21, SBV-Clubs): die Change-Gate-Zähler
+# (deep/skipped_unchanged) werden PRO Listeneintrag hochgezählt — eine LEERE Liste ist damit von
+# "alles unverändert" nicht unterscheidbar und lief bisher stumm durch (`deep=0 skipped_unchanged=0`).
+# Dieser Guard schlägt an, wenn eine Liste 0 Einträge liefert, obwohl in der DB bereits Einträge
+# stehen (> 0 also erwartbar waren). Reines Log-Signal — kein Einfluss auf den Scrape-Ablauf.
+module ScrapeListGuard
+  module_function
+
+  # true, wenn gewarnt wurde (leere Liste trotz Erwartung), sonst false.
+  def warn_if_empty(label, scraped_count, expected_count)
+    return false unless scraped_count.to_i.zero? && expected_count.to_i.positive?
+
+    Rails.logger.warn "===== scrape ===== LEERE LISTE #{label}: 0 Einträge gescrapet, " \
+                      "#{expected_count} in der DB — Quelle vermutlich defekt (fail-silent-Verdacht)"
+    true
+  end
+end

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -342,6 +342,7 @@ class League < ApplicationRecord
       leagues_doc = Nokogiri::HTML(leagues_html)
       table = leagues_doc.css("article table.silver")[1]
 
+      cc_list_count = 0         # Listeneinträge für diese Region/Saison (0 = Verdacht auf leere Liste)
       if table.present?
         cc_gate_deep = 0        # Change-Gate-Metrik (Phase 22): tief gescrapte Ligen
         cc_gate_skipped = 0     # Change-Gate-Metrik: unveränderte, übersprungene Ligen
@@ -357,6 +358,7 @@ class League < ApplicationRecord
           league_cc_id = params[3].to_i
           next if region_cc_id != region.cc_id || season_name != season.name
 
+          cc_list_count += 1
           title = a[0].text.strip
           short = tr.css("td")[1].text.strip
           n_staffel = tr.css("td")[2].text.strip.to_i
@@ -437,6 +439,8 @@ class League < ApplicationRecord
         Rails.logger.info "===== scrape ===== CC-Change-Gate #{region.shortname}: " \
                           "deep=#{cc_gate_deep} skipped_unchanged=#{cc_gate_skipped}"
       end
+      ScrapeListGuard.warn_if_empty("Leagues #{region.shortname} #{season.name}", cc_list_count,
+                                    League.where(season: season, organizer: region).count)
     end
   rescue StandardError => e
     Rails.logger.info "====== problem with leagues in region #{region.name} - leagues_url: #{leagues_url} e93 \

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -149,6 +149,8 @@ class Location < ApplicationRecord
       # (pro-Location-Detailfetches) nur bei geänderter Liste; sonst Region überspringen. Listen-Fetch
       # bleibt tägliche Grundkost. commit erst NACH Erfolg; leere/fehlerhafte Liste → stale → deep.
       content = region.location_list_content
+      ScrapeListGuard.warn_if_empty("Locations #{region.shortname}", content.lines.size,
+                                    Location.where(organizer: region).count)
       if ScrapeFingerprint.deep?(region, "locations", content)
         region.scrape_locations
         ScrapeFingerprint.for(region, "locations").commit!(content)

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -617,11 +617,14 @@ image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
     has_open = Tournament.where(season: season, organizer: self).left_joins(:games)
                          .where(games: { id: nil }).exists?
     unless ScrapeFingerprint.deep?(self, list_scope, list_content) || has_open || opts[:force]
+      ScrapeListGuard.warn_if_empty("Tournaments #{shortname} #{season.name}", list_content.lines.size,
+                                    Tournament.where(season:, organizer: self).count)
       Rails.logger.info "===== scrape ===== CC-Change-Gate Tournaments #{shortname} #{season.name}: " \
                         "deep=0 skipped_unchanged=1 (Liste unverändert, keine offenen Turniere)"
       return
     end
-    einzel_doc.css("article table.silver").andand[1].andand.css("tr").to_a[2..].to_a.each do |tr|
+    tournament_rows = einzel_doc.css("article table.silver").andand[1].andand.css("tr").to_a[2..].to_a
+    tournament_rows.each do |tr|
       lfnr = tr.css("td")[0].text.to_i
 
       #TODO remove following after successfull test!!!
@@ -712,6 +715,8 @@ image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
     # Deep erfolgreich → Turnier-Listen-digest festschreiben (nächster Lauf überspringt bei gleicher
     # Liste, sofern keine offenen Turniere).
     ScrapeFingerprint.for(self, list_scope).commit!(list_content)
+    ScrapeListGuard.warn_if_empty("Tournaments #{shortname} #{season.name}", tournament_rows.size,
+                                  Tournament.where(season:, organizer: self).count)
     Rails.logger.info "===== scrape ===== CC-Change-Gate Tournaments #{shortname} #{season.name}: " \
                       "deep=1 skipped_unchanged=0"
   rescue StandardError => e
@@ -873,6 +878,7 @@ image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
 
             club.scrape_club(season, ref, url, opts.merge(called_from_portal: shortname == "DBU", gate_stats: gate_stats))
           end
+          ScrapeListGuard.warn_if_empty("Clubs #{shortname}", clubs.size, Club.where(region_id: id).count)
           Rails.logger.info "===== scrape ===== CC-Change-Gate Clubs #{shortname}: " \
                             "deep=#{gate_stats[:deep]} skipped_unchanged=#{gate_stats[:skipped]}"
         else

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -105,6 +105,15 @@ class Tournament < ApplicationRecord
   scope :upcoming, -> { where('date >= ?', Date.today).order(date: :asc) }
   scope :in_year, ->(year) { year.present? ? where('EXTRACT(YEAR FROM date) = ?', year) : all }
 
+  # Plan 27-01: Entwuerfe aus der Saison-Kopie (Tournament::SeasonCopier). Kein eigener AASM-State und
+  # keine Spalte — das Kennzeichen liegt im serialisierten data-Hash (text-Spalte, coder: JSON).
+  # Rohformat verifiziert: {"draft":true,"copied_from_tournament_id":42} — ohne Leerzeichen.
+  # Spalte MUSS qualifiziert sein: der SearchService joint Tabellen, die ebenfalls eine data-Spalte
+  # haben (PG::AmbiguousColumn im tournaments#index).
+  DRAFT_MARKER = '"draft":true'
+  scope :drafts, -> { where("tournaments.data LIKE ?", "%#{DRAFT_MARKER}%") }
+  scope :without_drafts, -> { where("tournaments.data IS NULL OR tournaments.data NOT LIKE ?", "%#{DRAFT_MARKER}%") }
+
   #   data:
   #     {:table_ids=>["2", "4"],
   #      :balls_goal=>0,
@@ -530,6 +539,14 @@ class Tournament < ApplicationRecord
 
   def name
     title || shortname
+  end
+
+  # Plan 27-01: Entwurf aus der Saison-Kopie — noch nicht vom Sportwart freigegeben und deshalb aus
+  # der regulaeren Turnierliste ausgeblendet. Tolerant gegen String/Boolean und leeres data.
+  def draft?
+    return false unless data.is_a?(Hash)
+
+    ActiveModel::Type::Boolean.new.cast(data["draft"]).present?
   end
 
   # Prüft ob dieses Turnier ClubCloud-Ergebnisse hat

--- a/app/services/region_server/entry_list_importer.rb
+++ b/app/services/region_server/entry_list_importer.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module RegionServer
+  # Plan 28-01: Holt die MELDELISTE eines Region Servers auf die AUTHORITY.
+  #
+  # Pull, analog CC-Scrape (Betreiber-Vorgabe): die Authority fetcht das JSON-Dokument von
+  # `Api::EntryListsController` und legt daraus GLOBALE Records an. Danach verteilt der regulaere
+  # Versions-Sync sie an alle Instanzen — auch an den Location Server, wo gespielt wird.
+  #
+  # ID-UEBERSETZUNG (der Kern): Die Quelle liefert LOKALE IDs (>= MIN_ID, dort die normale Sequenz).
+  # Auf der Authority entstehen GLOBALE IDs (< MIN_ID). Die Verknuepfung laeuft NICHT ueber die ID,
+  # sondern ueber `source_url` — dieselbe Provenienz-Konvention wie bei CC/LigaManager/NuLiga:
+  #   source_url = "<region-server-base>/tournaments/<lokale-id>"
+  #
+  # Guard wie die uebrigen Importer: dry-run per Default, Schreiben nur mit armed:, broadcast-frei.
+  #
+  # ⚠️ Spieler werden AUFGELOEST, nie neu angelegt — Stammdaten bleiben DBU-CC-gepflegt
+  # ("CC-less" != "CC-frei"). Unaufloesbare Meldungen werden berichtet.
+  class EntryListImporter
+    Result = Struct.new(:tournaments_created, :tournaments_matched, :seedings_created,
+      :players_unresolved, :skipped_no_source_id, keyword_init: true)
+
+    def initialize(region:, season:, base_url: nil, armed: false, document: nil)
+      @region = region
+      @season = season
+      @base_url = (base_url.presence || default_base_url).to_s.chomp("/")
+      @armed = armed
+      @document = document
+    end
+
+    def call
+      doc = @document || fetch_document
+      raise ArgumentError, "Antwort enthält keine tournaments-Liste" unless doc.is_a?(Hash) && doc["tournaments"].is_a?(Array)
+
+      result = Result.new(tournaments_created: 0, tournaments_matched: 0, seedings_created: 0,
+        players_unresolved: [], skipped_no_source_id: 0)
+
+      doc["tournaments"].each { |payload| import_tournament(payload, result) }
+      result
+    end
+
+    private
+
+    # Konvention statt Datenhaltung: Region hat KEINE Spalte fuer ihre Server-URL
+    # (vgl. service_accounts.rake:77). Per base_url/ENV ueberschreibbar.
+    def default_base_url
+      "https://#{@region.shortname.to_s.downcase}.carambus.de"
+    end
+
+    def fetch_document
+      uri = URI("#{@base_url}/api/entry_lists?region=#{CGI.escape(@region.shortname.to_s)}" \
+                "&season=#{CGI.escape(@season.name.to_s)}")
+      response = Net::HTTP.get_response(uri)
+      raise "Quelle nicht erreichbar (HTTP #{response.code}): #{uri}" unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    end
+
+    def import_tournament(payload, result)
+      source_id = payload["source_tournament_id"]
+      if source_id.blank?
+        result.skipped_no_source_id += 1
+        return
+      end
+
+      source_url = "#{@base_url}/tournaments/#{source_id}"
+      existing = ::Tournament.find_by(source_url: source_url)
+
+      tournament = existing || build_tournament(payload, source_url, result)
+      result.tournaments_matched += 1 if existing
+
+      # Auch im dry-run (tournament == nil) die Meldungen durchgehen: die Zahl der entstehenden
+      # Seedings und vor allem die UNAUFLOESBAREN Spieler sind die eigentliche Information eines
+      # Probelaufs.
+      import_entries(tournament, payload["entries"], result)
+    end
+
+    def build_tournament(payload, source_url, result)
+      attrs = payload.slice(*::Tournament::SeasonCopier::STRUCTURE_ATTRIBUTES)
+      attrs["season_id"] = @season.id
+      attrs["region_id"] = @region.id
+      attrs["organizer_type"] = "Region"
+      attrs["organizer_id"] = @region.id
+      attrs["date"] = payload["date"]
+      attrs["end_date"] = payload["end_date"]
+      attrs["source_url"] = source_url
+      # CC-los entstanden — kein automatischer Upload (konsistent zu Plan 25-01).
+      attrs["auto_upload_to_cc"] = false
+
+      result.tournaments_created += 1
+      return nil unless @armed
+
+      ::Tournament.skip_cable_ready_updates do
+        ::Tournament.create!(attrs)
+      end
+    end
+
+    def import_entries(tournament, entries, result)
+      Array(entries).each do |entry|
+        player = resolve_player(entry)
+        if player.nil?
+          result.players_unresolved << entry_label(entry)
+          next
+        end
+
+        # tournament ist im dry-run nil (noch nicht angelegt) — dann existiert zwangslaeufig noch
+        # keine Meldung, alle zaehlen als neu.
+        next if tournament&.seedings&.exists?(player_id: player.id)
+
+        result.seedings_created += 1
+        next unless @armed && tournament
+
+        ::Seeding.skip_cable_ready_updates do
+          tournament.seedings.create!(
+            player_id: player.id,
+            position: entry["position"],
+            balls_goal: entry["balls_goal"]
+          )
+        end
+      end
+    end
+
+    # dbu_nr ist global eindeutig (Memory carambus-club-player-identity-numbers). Kein Fallback auf
+    # Namensmatch: ein falsch zugeordneter Spieler waere schlimmer als eine gemeldete Luecke.
+    def resolve_player(entry)
+      dbu_nr = entry["dbu_nr"]
+      return nil if dbu_nr.blank?
+
+      ::Player.find_by(dbu_nr: dbu_nr)
+    end
+
+    def entry_label(entry)
+      name = [entry["lastname"], entry["firstname"]].compact.join(", ")
+      club = entry["club"].presence
+      dbu = entry["dbu_nr"].presence || "ohne dbu_nr"
+      [name.presence || "(ohne Namen)", club, "DBU #{dbu}"].compact.join(" · ")
+    end
+  end
+end

--- a/app/services/tournament/season_copier.rb
+++ b/app/services/tournament/season_copier.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# Plan 27-01: Kopiert die TURNIER-STRUKTUR einer Saison in eine Zielsaison, um den Kaltstart eines
+# Verbands zu loesen, der von der ClubCloud auf Carambus wechselt. Historische Turnierdaten sind fuer
+# alle Verbaende aus dem CC-Scrape vorhanden und damit die natuerliche Vorlage.
+#
+# Verwendung (dry-run ist Default):
+#   Tournament::SeasonCopier.new(region:, from_season:, to_season:).call
+#   Tournament::SeasonCopier.new(region:, from_season:, to_season:, armed: true).call
+#
+# ⚠️ LEITPLANKE (Memory cc-season-rollover-contamination): Genau dieses Kopieren hat die ClubCloud
+# beim Saison-Rollover falsch gemacht — sie kopierte den Vorjahres-Teilbaum INKLUSIVE Ergebnissen und
+# Original-Datteln und erzeugte damit monatelange Datenverwirrung. Dieser Service kopiert
+# ausschliesslich Struktur, verschiebt das Datum und markiert das Ergebnis als Entwurf:
+#   - keine Seedings, keine Games, kein TournamentMonitor
+#   - keine Provenienz fremder Quellen (ba_id/source_url/external_id/sync_date/ba_state)
+#   - state bleibt der Default (new_tournament)
+#
+# PORO (kein ApplicationService) gemaess der Konvention von Tournament::RankingCalculator.
+class Tournament::SeasonCopier
+  # Struktur-Attribute, die eine Turnier-"Vorlage" ausmachen. Bewusst als WHITELIST gefuehrt:
+  # eine Blacklist wuerde bei jeder neuen Spalte stillschweigend zu viel kopieren.
+  STRUCTURE_ATTRIBUTES = %w[
+    title shortname discipline_id modus age_restriction player_class tournament_plan_id
+    innings_goal balls_goal handicap_tournier location_id location_text single_or_league
+    team_size sets_to_win sets_to_play timeout timeouts kickoff_switches_with fixed_display_left
+    color_remains_with_set allow_follow_up allow_overflow continuous_placements manual_assignment
+    admin_controlled gd_has_prio time_out_warm_up_first_min time_out_warm_up_follow_up_min
+  ].freeze
+
+  # Eine Saison = 52 Wochen, NICHT "1 Jahr": so bleibt der Wochentag erhalten (Turniere liegen auf
+  # Wochenenden — ein Samstagsturnier soll wieder auf einen Samstag fallen).
+  WEEKS_PER_SEASON = 52
+
+  Result = Struct.new(:created, :skipped_existing, :skipped_no_date, :planned, keyword_init: true)
+
+  def initialize(region:, from_season:, to_season:, armed: false)
+    @region = region
+    @from_season = from_season
+    @to_season = to_season
+    @armed = armed
+  end
+
+  def call
+    distance = season_distance
+    raise ArgumentError, "Saison-Abstand nicht bestimmbar (#{@from_season&.name} -> #{@to_season&.name})" if distance.nil?
+    raise ArgumentError, "Zielsaison liegt nicht nach der Quellsaison" unless distance.positive?
+
+    result = Result.new(created: 0, skipped_existing: 0, skipped_no_date: 0, planned: [])
+
+    source_tournaments.find_each do |source|
+      unless usable_date?(source.date)
+        result.skipped_no_date += 1
+        next
+      end
+      if already_copied?(source)
+        result.skipped_existing += 1
+        next
+      end
+
+      new_date = shift(source.date, distance)
+      result.planned << {title: source.title, from: source.date.to_date, to: new_date.to_date}
+
+      next unless @armed
+
+      create_copy(source, distance)
+      result.created += 1
+    end
+
+    result
+  end
+
+  private
+
+  # Einzelmeisterschaften der Quellsaison, die diese Region ausrichtet. Liga-Turniere bleiben aussen
+  # vor — deren Struktur kommt aus dem Liga-Betrieb, nicht aus einer Saison-Kopie.
+  def source_tournaments
+    ::Tournament
+      .where(season_id: @from_season.id, organizer_type: "Region", organizer_id: @region.id)
+      # NICHT `where.not(single_or_league: "league")`: SQL schliesst NULL-Werte aus einem !=-Vergleich
+      # aus — und die meisten Turniere haben dort NULL. Sie waeren stillschweigend nie kopiert worden.
+      .where("single_or_league IS NULL OR single_or_league != ?", "league")
+      .order(:date)
+  end
+
+  # Idempotenz: in der Zielsaison darf pro Quellturnier hoechstens eine Kopie liegen. Der Schluessel
+  # steht im data-Hash, weil es dafuer keine Spalte gibt (und keine Migration geben soll).
+  def already_copied?(source)
+    ::Tournament
+      .where(season_id: @to_season.id, organizer_type: "Region", organizer_id: @region.id)
+      .any? { |t| t.data.is_a?(Hash) && t.data["copied_from_tournament_id"].to_i == source.id }
+  end
+
+  def create_copy(source, distance)
+    attrs = source.attributes.slice(*STRUCTURE_ATTRIBUTES)
+    attrs["season_id"] = @to_season.id
+    attrs["region_id"] = @region.id
+    attrs["organizer_type"] = "Region"
+    attrs["organizer_id"] = @region.id
+    attrs["date"] = shift(source.date, distance)
+    attrs["end_date"] = shift(source.end_date, distance) if source.end_date.present?
+    # CC-los angelegt — kein automatischer Upload (konsistent zu Plan 25-01).
+    attrs["auto_upload_to_cc"] = false
+    attrs["data"] = {"draft" => true, "copied_from_tournament_id" => source.id}
+
+    ::Tournament.skip_cable_ready_updates do
+      ::Tournament.create!(attrs)
+    end
+  end
+
+  # Ein Turnier "ohne Datum" gibt es in diesem Modell nicht: `Tournament` setzt in einem before_save
+  # `self.date = Time.at(0) if date.blank?` (tournament.rb:352). Ein Epoch-Datum ist also der
+  # Platzhalter fuer "unbekannt" — eine Kopie davon waere Muell und wird uebersprungen.
+  def usable_date?(time)
+    time.present? && time.year > 1970
+  end
+
+  def shift(time, distance)
+    return nil if time.blank?
+
+    time + (distance * WEEKS_PER_SEASON).weeks
+  end
+
+  # Abstand in Saisons aus den NAMEN ("2024/2025" -> 2024), nicht aus IDs: IDs sind nicht
+  # zwingend luecken- oder reihenfolgetreu.
+  def season_distance
+    from_year = start_year(@from_season)
+    to_year = start_year(@to_season)
+    return nil if from_year.nil? || to_year.nil?
+
+    to_year - from_year
+  end
+
+  def start_year(season)
+    name = season&.name.to_s
+    return nil unless ::Season::VALID_NAME_REGEX.match?(name)
+
+    name[0, 4].to_i
+  end
+end

--- a/app/services/tournament_monitor/result_processor.rb
+++ b/app/services/tournament_monitor/result_processor.rb
@@ -520,7 +520,7 @@ result: #{result}, innings: #{innings}, gd: #{gd}, hs: #{hs}, sets: #{sets}")
     f = File.new("#{Rails.root}/tmp/result-#{@tournament_monitor.tournament.cc_id}.csv", "w")
     f.write(game_data.join("\n"))
     f.close
-    emails = ["gernot.ullrich@gmx.de"]
+    emails = []
 
     # Safely try to fetch current_admin email without crashing
     begin

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -10,6 +10,18 @@
 <!--<br>-->
 <%= form_with model: @tournament do |form| %>
 
+  <%- if @tournament.errors.any? %>
+    <div class="form-group rounded border border-danger-500 bg-danger-50 p-4 text-danger-700 dark:bg-danger-900 dark:text-danger-200">
+      <p class="font-semibold"><%= t('tournaments.form.errors_headline', count: @tournament.errors.count,
+                                     default: "Das Turnier konnte nicht gespeichert werden:") %></p>
+      <ul class="list-disc ml-5">
+        <%- @tournament.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <%- end %>
+      </ul>
+    </div>
+  <%- end %>
+
   <%- loc_ids = (Array(Location.joins(:tables).where(organizer_type: @tournament.organizer_type, organizer_id: @tournament.organizer_id).andand.map(&:id)) +
     Array(@tournament.andand.region.andand.clubs.andand.map { |club| club.locations.andand.joins(:tables).to_a }.andand.flatten.andand.map(&:id))).uniq
   %>
@@ -24,6 +36,18 @@
     <%= form.label :title %>
     <%= form.text_field :title, class: "border rounded border-gray-500" %>
   </div>
+  <div class="form-group">
+    <%= form.label :shortname %>
+    <%= form.text_field :shortname, class: "border rounded border-gray-500" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :date %>
+    <%= form.datetime_field :date, class: "border rounded border-gray-500" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :end_date %>
+    <%= form.datetime_field :end_date, class: "border rounded border-gray-500" %>
+  </div>
   <%- if @tournament.new_record? && @tournament.organizer.present? %>
     <div class="form-group">
       <%= form.label :organizer %>
@@ -33,7 +57,7 @@
     </div>
     <div class="form-group">
       <%= form.label :season_id %>
-      <%= season.name %>
+      <%= @tournament.season.andand.name %>
       <%= form.hidden_field :season_id %>
     </div>
   <%- end %>
@@ -128,8 +152,8 @@
 
   <div class="field-unit">
     <%= form.label :source_url, t('tournaments.form.clubcloud_url') %>
-    <%= form.text_field :source_url, disabled: @tournament.id < Tournament::MIN_ID %>
-    <% if @tournament.id < Tournament::MIN_ID %>
+    <%= form.text_field :source_url, disabled: @tournament.id.present? && @tournament.id < Tournament::MIN_ID %>
+    <% if @tournament.id.present? && @tournament.id < Tournament::MIN_ID %>
       <small class="hint"><%= t('tournaments.form.imported_tournament_note') %></small>
     <% end %>
   </div>

--- a/app/views/tournaments/define_participants.html.erb
+++ b/app/views/tournaments/define_participants.html.erb
@@ -394,6 +394,50 @@
           </div>
         <% end %>
 
+        <%# Plan 26-01: Meldung über Verein → Spieler (nur Region-Turniere — bei Club-Turnieren
+            listet der Block oben bereits die Vereinsspieler). Speist bewusst das bestehende
+            add_player_by_dbu-Formular: das Spieler-Select trägt die dbu_nr als Wert. %>
+        <%- if @tournament.organizer.is_a?(Region) %>
+          <%- entry_list_clubs = entry_list_clubs_for(@tournament) %>
+          <%- if entry_list_clubs.any? %>
+            <div class="mt-6 p-4 rounded border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800"
+                 data-controller="dependent-select"
+                 data-dependent-select-url-value="<%= players_by_club_tournament_path(@tournament) %>"
+                 data-dependent-select-value-key-value="dbu_nr"
+                 data-dependent-select-placeholder-value="<%= t('tournaments.define_participants.select_player_blank', default: '— Spieler wählen —') %>">
+              <h4 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                <%= t('tournaments.define_participants.add_by_club_heading', default: 'Teilnehmer über den Verein melden') %>
+              </h4>
+              <p class="text-sm text-gray-600 dark:text-gray-300 mb-3">
+                <%= t('tournaments.define_participants.add_by_club_hint',
+                      default: 'Verein wählen, dann den Spieler. Vereine mit bereits gemeldeten Teilnehmern und der Austragungsort stehen oben.') %>
+              </p>
+
+              <div class="flex gap-2 items-start flex-wrap">
+                <div class="flex-1 min-w-[12rem]">
+                  <%= select_tag :entry_list_club_id,
+                        options_for_select(entry_list_clubs),
+                        include_blank: t('tournaments.define_participants.select_club_blank', default: '— Verein wählen —'),
+                        class: 'form-control',
+                        data: { dependent_select_target: 'source', action: 'dependent-select#load' } %>
+                </div>
+
+                <%= form_with url: add_player_by_dbu_tournament_path(@tournament), method: :post, local: true,
+                              class: 'flex gap-2 items-start flex-1 min-w-[14rem]' do |f| %>
+                  <div class="flex-1">
+                    <%= select_tag :dbu_nr, nil, class: 'form-control',
+                          required: true,
+                          data: { dependent_select_target: 'dest' } %>
+                  </div>
+                  <%= f.submit t('tournaments.define_participants.add_player_button'),
+                        class: 'btn btn-sm btn-primary',
+                        data: { disable_with: t('tournaments.define_participants.searching') } %>
+                <% end %>
+              </div>
+            </div>
+          <%- end %>
+        <%- end %>
+
         <!-- Spieler hinzufügen (kurzfristige Nachmeldung) -->
         <div class="mt-6 p-4 bg-yellow-50 border border-yellow-200 rounded">
           <h4 class="font-semibold text-yellow-900 mb-2"><%= t('tournaments.define_participants.late_registration_heading') %></h4>

--- a/app/views/tournaments/index.html.erb
+++ b/app/views/tournaments/index.html.erb
@@ -16,6 +16,23 @@
   </div>
 <% end %>
 
+<%# Plan 27-01: Entwuerfe aus der Saison-Kopie sind standardmaessig ausgeblendet. Der Umschalter macht
+    sie auffindbar — ohne ihn waeren sie nach einem Kopier-Lauf unsichtbar. %>
+<% if local_server? %>
+  <div class="container mx-auto px-4 mb-2 text-sm">
+    <% if @show_drafts %>
+      <span class="inline-block rounded px-2 py-1 bg-warning-100 text-warning-900 dark:bg-warning-900 dark:text-warning-100">
+        <%= t('tournaments.index.showing_drafts', default: 'Es werden nur Entwürfe angezeigt (aus der Saison-Kopie).') %>
+      </span>
+      <%= link_to t('tournaments.index.show_regular', default: 'Reguläre Turniere anzeigen'),
+            tournaments_path, class: 'ml-2 text-primary-600 dark:text-primary-300 underline' %>
+    <% else %>
+      <%= link_to t('tournaments.index.show_drafts', default: 'Entwürfe anzeigen'),
+            tournaments_path(drafts: 1), class: 'text-primary-600 dark:text-primary-300 underline' %>
+    <% end %>
+  </div>
+<% end %>
+
 <%= render partial: 'shared/index_with_search', locals: {
   model_class: Tournament,
   records: @tournaments,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,10 @@ Rails.application.routes.draw do
       end
     end
 
+    # Plan 28-01: Meldeliste einer Region/Saison als JSON — die Authority holt sie sich hier ab
+    # (Pull, analog CC-Scrape) und uebersetzt die lokalen IDs in globale.
+    resources :entry_lists, only: [:index]
+
     resources :locations, only: [] do
       collection do
         get :autocomplete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -361,6 +361,8 @@ Rails.application.routes.draw do
       post :use_clubcloud_as_participants
       post :update_seeding_position
       post :add_player_by_dbu
+      # Plan 26-01: Spieler eines Vereins (JSON) fuer die Club->Spieler-Kaskade der Meldeliste.
+      get :players_by_club
       post :recalculate_groups
       post :test_tournament_status_update
     end

--- a/lib/tasks/region_server.rake
+++ b/lib/tasks/region_server.rake
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+namespace :region_server do
+  # Plan 28-01: Holt die MELDELISTE eines Region Servers auf die AUTHORITY (Pull, analog CC-Scrape)
+  # und uebersetzt dabei die lokalen IDs der Quelle in globale Records. Der regulaere Versions-Sync
+  # verteilt sie anschliessend an alle Instanzen — auch an den Location Server, wo gespielt wird.
+  #
+  # BLAST-RADIUS: genau EINE Region und EINE Saison. Keine Defaults — beides muss explizit angegeben
+  # werden (ein implizites current_season hat beim CC-Rollover Schaden angerichtet).
+  #
+  # ⚠️ Spieler werden ueber dbu_nr AUFGELOEST, nie neu angelegt. Unaufloesbare Meldungen werden
+  # berichtet und sind Nacharbeit — Stammdaten bleiben DBU-CC-gepflegt.
+  #
+  #   bin/rails region_server:import_entry_lists REGION=NBV SEASON=2026/2027            # dry-run
+  #   ARMED=1 bin/rails region_server:import_entry_lists REGION=NBV SEASON=2026/2027    # schreibt
+  #   BASE_URL=http://localhost:3001 bin/rails region_server:import_entry_lists ...     # abweichende Quelle
+  desc "Meldeliste eines Region Servers auf die Authority holen — dry-run default, ARMED=1 schreibt"
+  task import_entry_lists: :environment do
+    shortname = ENV["REGION"].to_s.strip
+    season_name = ENV["SEASON"].to_s.strip
+    base_url = ENV["BASE_URL"].presence
+    armed = ENV["ARMED"].present?
+
+    if shortname.blank? || season_name.blank?
+      puts "Usage: bin/rails region_server:import_entry_lists REGION=NBV SEASON=2026/2027 [ARMED=1] [BASE_URL=...]"
+      exit 1
+    end
+
+    region = Region.find_by("UPPER(shortname) = ?", shortname.upcase)
+    season = Season.find_by(name: season_name)
+    abort "Region '#{shortname}' nicht gefunden" if region.nil?
+    abort "Saison '#{season_name}' nicht gefunden" if season.nil?
+
+    effective_base = base_url || "https://#{region.shortname.downcase}.carambus.de"
+
+    puts "=" * 78
+    puts "Meldelisten-Ingest #{region.shortname} #{season.name}"
+    puts "Quelle: #{effective_base}"
+    puts armed ? "MODUS: ARMED — es wird geschrieben" : "MODUS: dry-run — es wird NICHTS geschrieben"
+    puts "Blast-Radius: nur Region #{region.shortname}, nur Saison #{season.name}"
+    puts "=" * 78
+
+    begin
+      result = RegionServer::EntryListImporter.new(
+        region: region, season: season, base_url: base_url, armed: armed
+      ).call
+    rescue => e
+      abort "Ingest abgebrochen: #{e.message}"
+    end
+
+    puts "\nErgebnis:"
+    puts "  Turniere neu:              #{result.tournaments_created}"
+    puts "  Turniere bereits vorhanden: #{result.tournaments_matched}"
+    puts "  Meldungen neu:             #{result.seedings_created}"
+    puts "  ohne Quell-Kennung übersprungen: #{result.skipped_no_source_id}"
+
+    if result.players_unresolved.any?
+      puts "\n⚠️  #{result.players_unresolved.size} Meldung(en) NICHT zuordenbar — diese Spieler kennt die"
+      puts "    Authority nicht. Sie wurden NICHT angelegt (Stammdaten bleiben CC-gepflegt):"
+      result.players_unresolved.each { |label| puts "      - #{label}" }
+    end
+
+    puts "\nDRY-RUN — für echtes Schreiben ARMED=1 setzen." unless armed
+  end
+end

--- a/lib/tasks/tournaments.rake
+++ b/lib/tasks/tournaments.rake
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+namespace :tournaments do
+  # Plan 27-01: Kaltstart-Hilfe für einen Verband, der von der ClubCloud auf Carambus wechselt.
+  # Kopiert die TURNIER-STRUKTUR einer abgelaufenen Saison in eine Zielsaison — Datum um n·52 Wochen
+  # verschoben (Wochentag bleibt erhalten), als Entwurf angelegt (data["draft"]).
+  #
+  # BLAST-RADIUS: genau EINE Region und EINE Zielsaison. Keine Defaults — Region und beide Saisons
+  # müssen explizit angegeben werden (ein implizites current_season hat beim CC-Rollover Schaden
+  # angerichtet).
+  #
+  # ⚠️ Kopiert NIEMALS Ergebnisse, Seedings, Spiele oder fremde Provenienz (ba_id/source_url/...).
+  #
+  #   bin/rails tournaments:copy_season REGION=NBV FROM=2024/2025 TO=2026/2027           # dry-run
+  #   ARMED=1 bin/rails tournaments:copy_season REGION=NBV FROM=2024/2025 TO=2026/2027   # schreibt
+  desc "Turnier-Struktur einer Saison in eine Zielsaison kopieren (Entwürfe) — dry-run default, ARMED=1 schreibt"
+  task copy_season: :environment do
+    shortname = ENV["REGION"].to_s.strip
+    from_name = ENV["FROM"].to_s.strip
+    to_name = ENV["TO"].to_s.strip
+    armed = ENV["ARMED"].present?
+
+    if shortname.blank? || from_name.blank? || to_name.blank?
+      puts "Usage: bin/rails tournaments:copy_season REGION=NBV FROM=2024/2025 TO=2026/2027 [ARMED=1]"
+      exit 1
+    end
+
+    region = Region.find_by("UPPER(shortname) = ?", shortname.upcase)
+    from_season = Season.find_by(name: from_name)
+    to_season = Season.find_by(name: to_name)
+
+    abort "Region '#{shortname}' nicht gefunden" if region.nil?
+    abort "Saison '#{from_name}' nicht gefunden" if from_season.nil?
+    abort "Saison '#{to_name}' nicht gefunden" if to_season.nil?
+
+    puts "=" * 78
+    puts "Saison-Kopie #{region.shortname}: #{from_season.name} → #{to_season.name}"
+    puts armed ? "MODUS: ARMED — es wird geschrieben" : "MODUS: dry-run — es wird NICHTS geschrieben"
+    puts "Blast-Radius: nur Region #{region.shortname}, nur Zielsaison #{to_season.name}"
+    puts "=" * 78
+
+    result = Tournament::SeasonCopier.new(
+      region: region, from_season: from_season, to_season: to_season, armed: armed
+    ).call
+
+    if result.planned.any?
+      puts "\nTurniere, die kopiert werden#{" würden" unless armed}:"
+      result.planned.each do |row|
+        puts format("  %-45s %s → %s", row[:title].to_s[0, 45], row[:from], row[:to])
+      end
+    end
+
+    puts "\nErgebnis:"
+    puts "  angelegt:              #{result.created}"
+    puts "  übersprungen (Kopie existiert): #{result.skipped_existing}"
+    puts "  übersprungen (kein brauchbares Datum): #{result.skipped_no_date}"
+    puts "\nHinweis: Kopien sind Entwürfe und in der Turnierliste ausgeblendet." if result.created.positive?
+    puts "Sichtbar über den Umschalter „Entwürfe anzeigen“ (/tournaments?drafts=1)." if result.created.positive?
+    puts "\nDRY-RUN — für echtes Schreiben ARMED=1 setzen." unless armed
+  end
+end

--- a/test/controllers/api/entry_lists_controller_test.rb
+++ b/test/controllers/api/entry_lists_controller_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Plan 28-01: Ausliefer-Endpunkt der Meldeliste (laeuft auf dem Region Server).
+class Api::EntryListsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @region = regions(:nbv)
+    @season = seasons(:current)
+    @user = users(:one)
+
+    @tournament = Tournament.create!(
+      title: "Landesmeisterschaft Einband", shortname: "LME",
+      season: @season, organizer: @region, region_id: @region.id,
+      date: Time.zone.local(2026, 10, 10, 10, 0), player_class: "I", balls_goal: 100
+    )
+    @club = Club.create!(name: "Meldeverein", shortname: "MV", region_id: @region.id)
+    @player = Player.create!(lastname: "MELDER", firstname: "Mia", fl_name: "M. Melder", dbu_nr: 424_242)
+    SeasonParticipation.create!(player: @player, club: @club, season: @season)
+    @tournament.seedings.create!(player_id: @player.id, position: 1)
+  end
+
+  def get_entry_lists(region: @region.shortname, season: @season.name)
+    get api_entry_lists_url(region: region, season: season)
+  end
+
+  test "ohne Authentifizierung kein Zugriff" do
+    get_entry_lists
+    refute_equal 200, response.status, "unauthentifiziert darf die Meldeliste nicht ausgeliefert werden"
+  end
+
+  test "liefert Turnier mit gemeldeten Spielern" do
+    sign_in @user
+    get_entry_lists
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal "carambus.entry_list/v1", body["schema"]
+    assert_equal @region.shortname, body.dig("region", "shortname")
+
+    tournament = body["tournaments"].find { |t| t["source_tournament_id"] == @tournament.id }
+    assert tournament, "Turnier muss enthalten sein"
+    assert_equal "Landesmeisterschaft Einband", tournament["title"]
+    assert_equal 100, tournament["balls_goal"]
+
+    entry = tournament["entries"].first
+    assert_equal 424_242, entry["dbu_nr"]
+    assert_equal "MELDER", entry["lastname"]
+    assert_equal "Meldeverein", entry["club"], "Verein reist als Gegenprobe mit"
+  end
+
+  test "Turnier ohne Meldungen erscheint mit leerer Liste" do
+    sign_in @user
+    leer = Tournament.create!(title: "Noch keine Meldungen", season: @season,
+      organizer: @region, date: Time.zone.local(2026, 11, 1, 10, 0))
+
+    get_entry_lists
+
+    tournament = JSON.parse(response.body)["tournaments"].find { |t| t["source_tournament_id"] == leer.id }
+    assert tournament, "Turnier ohne Meldungen darf nicht fehlen"
+    assert_equal [], tournament["entries"]
+  end
+
+  test "Entwuerfe aus der Saison-Kopie werden NICHT ausgeliefert" do
+    sign_in @user
+    draft = Tournament.create!(title: "Entwurf aus Kopie", season: @season, organizer: @region,
+      date: Time.zone.local(2026, 12, 1, 10, 0), data: {"draft" => true})
+
+    get_entry_lists
+
+    ids = JSON.parse(response.body)["tournaments"].map { |t| t["source_tournament_id"] }
+    refute_includes ids, draft.id, "nicht freigegebene Entwuerfe duerfen nicht global werden"
+  end
+
+  test "unbekannte Region und Saison werden abgewiesen" do
+    sign_in @user
+
+    get_entry_lists(region: "GIBTESNICHT")
+    assert_response :not_found
+
+    get_entry_lists(season: "1999/2000")
+    assert_response :not_found
+  end
+end

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -780,4 +780,26 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     # Das bestehende DBU-Textfeld bleibt als Weg fuer Gastspieler erhalten.
     assert_select "input[name=?]", "dbu_nr"
   end
+
+  # Plan 27-01: Entwuerfe aus der Saison-Kopie sind in der regulaeren Liste ausgeblendet.
+
+  # Plan 27-01: Entwurfs-Ausblendung im Index.
+  #
+  # BEFUND: Ein Integrationstest kann den Listeninhalt hier nicht pruefen — der SearchService
+  # liefert im Testkontext generell 0 Records (13 Turniere in der DB, `results.count == 0`
+  # schon VOR jedem Draft-Filter). Das ist vorbestehend und unabhaengig von dieser Aenderung.
+  # Geprueft wird daher, dass der Index mit und ohne `drafts`-Param fehlerfrei rendert
+  # (Regression: die Scopes muessen `tournaments.data` qualifizieren, sonst PG::AmbiguousColumn).
+  # Die Trennung der Mengen deckt tournament_test.rb ueber die Scopes ab.
+  test "GET index rendert mit und ohne drafts-Param" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    Tournament.create!(title: "Entwurfskopie", season: @tournament.season,
+      organizer: regions(:nbv), date: 3.weeks.from_now, data: {"draft" => true})
+
+    get tournaments_url
+    assert_response :success
+
+    get tournaments_url(drafts: 1)
+    assert_response :success
+  end
 end

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -700,4 +700,84 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
       "Validierungsfehler muessen sichtbar werden (vorher: stiller redirect_back)"
     assert_select "form"
   end
+
+  # ---------------------------------------------------------------------------
+  # Plan 26-01: players_by_club — speist die Club->Spieler-Kaskade der Meldeliste.
+  # Bei Region-Turnieren war die Teilnehmerauswahl bisher zirkulaer (nur Spieler MIT
+  # Seeding in genau diesem Turnier) und damit immer leer.
+  # ---------------------------------------------------------------------------
+
+  def seed_club_with_players
+    club = Club.create!(name: "Testverein 26", shortname: "TV26", region_id: 50_000_001)
+    # Saison des Turniers — der Endpunkt filtert danach (nicht nach Season.current_season,
+    # die in der Testumgebung nil ist).
+    season = @tournament.season
+    a = Player.create!(lastname: "ALPHA", firstname: "Anna", fl_name: "A. Alpha", dbu_nr: "111111")
+    b = Player.create!(lastname: "BETA", firstname: "Bert", fl_name: "B. Beta", dbu_nr: "222222")
+    [a, b].each { |pl| SeasonParticipation.create!(player: pl, club: club, season: season) }
+    [club, a, b]
+  end
+
+  test "GET players_by_club returns the club players with dbu_nr" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    club, a, b = seed_club_with_players
+
+    get players_by_club_tournament_url(@tournament, club_id: club.id)
+
+    assert_response :success
+    rows = JSON.parse(response.body)
+    assert_equal 2, rows.size
+    assert_equal [a.id, b.id].sort, rows.map { |r| r["id"] }.sort
+    assert_equal [111_111, 222_222], rows.map { |r| r["dbu_nr"] }.sort  # dbu_nr ist integer
+    assert rows.all? { |r| r["label"].present? }, "label muss gesetzt sein"
+  end
+
+  test "GET players_by_club without club_id returns an empty list" do
+    Carambus.config.carambus_api_url = "http://local.test"
+
+    get players_by_club_tournament_url(@tournament)
+
+    assert_response :success
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test "GET players_by_club omits players already seeded in this tournament" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    club, a, _b = seed_club_with_players
+    @tournament.seedings.create!(player_id: a.id, position: 1)
+
+    get players_by_club_tournament_url(@tournament, club_id: club.id)
+
+    rows = JSON.parse(response.body)
+    refute_includes rows.map { |r| r["id"] }, a.id,
+      "bereits gemeldeter Spieler darf nicht erneut angeboten werden"
+    assert_equal 1, rows.size
+  end
+
+  test "GET players_by_club redirects to tournaments_path when not local server" do
+    Carambus.config.carambus_api_url = nil
+
+    get players_by_club_tournament_url(@tournament, club_id: 1)
+
+    assert_redirected_to tournaments_path
+  end
+
+  test "GET define_participants renders the club cascade for a region tournament" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    club, _a, _b = seed_club_with_players
+
+    get define_participants_tournament_url(@tournament)
+
+    assert_response :success
+    assert_select "[data-controller='dependent-select']", 1,
+      "Kaskaden-Block muss bei Region-Turnieren gerendert werden"
+    assert_select "select[name=?]", "entry_list_club_id" do
+      assert_select "option[value=?]", club.id.to_s
+    end
+    # Das Spieler-Select speist add_player_by_dbu direkt (name=dbu_nr).
+    assert_select "form[action=?] select[name=?]",
+      add_player_by_dbu_tournament_path(@tournament), "dbu_nr"
+    # Das bestehende DBU-Textfeld bleibt als Weg fuer Gastspieler erhalten.
+    assert_select "input[name=?]", "dbu_nr"
+  end
 end

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -561,7 +561,10 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
 
   test "PATCH update mit TL-change — Sportwart-im-Wirkbereich-User → success + TL updated" do
     Carambus.config.carambus_api_url = "http://local.test"
-    sportwart = User.create!(email: "ctrl_sw@test.de", password: "password123", confirmed_at: Time.current)
+    # D-38: Sportwart-Mitgliedschaft ist EXPLIZIT (persona_grants), nicht aus der
+    # Join-Praesenz abgeleitet — ohne Grant liefert in_sportwart_scope? false.
+    sportwart = User.create!(email: "ctrl_sw@test.de", password: "password123",
+      confirmed_at: Time.current, persona_grants: ["sportwart"])
     sportwart.sportwart_locations << locations(:one)
     sportwart.sportwart_disciplines << disciplines(:carom_3band)
     # Repair fixture-rot: ensure tournament has matching location + discipline
@@ -573,6 +576,8 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     patch tournament_url(@tournament), params: {tournament: {turnier_leiter_user_id: new_tl.id}}
 
     assert_includes [200, 302], response.status, "update should succeed"
+    # 302 ist mehrdeutig (Erfolg UND Pundit-Deny redirecten) — Deny explizit ausschliessen.
+    assert_nil flash[:alert], "kein Authority-Deny erwartet"
     @tournament.reload
     assert_equal new_tl.id, @tournament.turnier_leiter_user_id, "TL muss gesetzt sein"
   end
@@ -617,6 +622,21 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     assert_includes [200, 302], response.status, "update OHNE TL-change muss durchgehen"
     @tournament.reload
     assert_equal "Updated Title Smoke", @tournament.title
+  end
+
+  test "PATCH update meldet unerwartete Fehler sichtbar statt still (vorher: 204 No Content)" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    original_title = @tournament.title
+
+    # organizer_type auf eine nicht existierende Klasse => NameError beim Speichern.
+    patch tournament_url(@tournament), params: {tournament: {
+      title: "Darf nicht durchkommen", organizer_type: "NoSuchClassXY", organizer_id: 1
+    }}
+
+    assert_response :unprocessable_entity, "Fehler muss sichtbar werden, nicht als 204 verschwinden"
+    assert_match(/Aktualisierung fehlgeschlagen/, flash[:alert].to_s)
+    @tournament.reload
+    assert_equal original_title, @tournament.title
   end
 
   # ---------------------------------------------------------------------------

--- a/test/controllers/tournaments_controller_test.rb
+++ b/test/controllers/tournaments_controller_test.rb
@@ -101,12 +101,20 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
   # Auth guard: write actions require sign-in
   # ---------------------------------------------------------------------------
 
-  test "unauthenticated POST create redirects to sign in" do
+  # BEFUND (Plan 25-01): Der Test hiess frueher "unauthenticated POST create redirects to
+  # sign in" und prueft NICHT, was der Name behauptete — TournamentsController hat KEIN
+  # `authenticate_user!`. Der beobachtete 302 kam vom `redirect_back` des Validierungsfehlers,
+  # nicht von einem Login-Redirect. Seit 25-01 rendert #create bei Fehlern 422, wodurch das
+  # sichtbar wurde. Verhalten unveraendert gelassen (Boundary: keine Autorisierungsaenderung),
+  # aber gemeldet. Was der Test tatsaechlich sichert: es wird nichts angelegt.
+  test "unauthenticated POST create does not persist a tournament" do
     sign_out @user
     Carambus.config.carambus_api_url = "http://local.test"
-    post tournaments_url, params: { tournament: { title: "New Tournament" } }
-    # Either redirects to sign-in or is blocked by ensure_local_server (tournaments_path)
-    assert_includes [302], response.status
+
+    assert_no_difference("Tournament.count") do
+      post tournaments_url, params: { tournament: { title: "New Tournament" } }
+    end
+    assert_includes [302, 422], response.status
   end
 
   # ---------------------------------------------------------------------------
@@ -609,5 +617,87 @@ class TournamentsControllerTest < ActionDispatch::IntegrationTest
     assert_includes [200, 302], response.status, "update OHNE TL-change muss durchgehen"
     @tournament.reload
     assert_equal "Updated Title Smoke", @tournament.title
+  end
+
+  # ---------------------------------------------------------------------------
+  # Plan 25-01: Anlage-Blocker. Bis hierher war KEIN manueller Anlage-Weg im UI
+  # benutzbar — _form.html.erb rief `@tournament.id < MIN_ID` bei id == nil
+  # (NoMethodError). Die bestehenden Guard-Tests oben tolerieren Status 500
+  # ausdruecklich ("view dependency") und haben den Blocker deshalb nie gefangen.
+  # Die folgenden Tests verlangen 200 strikt.
+  # ---------------------------------------------------------------------------
+
+  test "GET new renders the form (regression: NoMethodError on nil id)" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    get new_tournament_url
+
+    assert_response :success, "new muss das Formular rendern, nicht mit 500 sterben"
+    assert_select "form" do
+      assert_select "input[name=?]", "tournament[title]"
+      assert_select "input[name=?]", "tournament[shortname]"
+      assert_select "input[name=?]", "tournament[date]"
+      assert_select "input[name=?]", "tournament[end_date]"
+      assert_select "input[name=?]", "tournament[source_url]"
+    end
+  end
+
+  test "GET new leaves source_url editable for a new record" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    get new_tournament_url
+
+    assert_response :success
+    assert_select "input[name=?][disabled]", "tournament[source_url]", 0,
+      "source_url darf bei Neuanlage NICHT disabled sein"
+  end
+
+  test "GET edit keeps source_url disabled for an imported (global) tournament" do
+    Carambus.config.carambus_api_url = "http://local.test"
+    imported = tournaments(:imported)
+    assert imported.id < Tournament::MIN_ID, "Fixture-Vorbedingung: globales Turnier"
+
+    get edit_tournament_url(imported)
+
+    assert_response :success
+    # Hinweis: keine Message als 3. Argument — assert_select deutet sie als Equality-Test.
+    assert_select "input[name=?][disabled]", "tournament[source_url]"
+  end
+
+  test "POST create persists tournament and disables auto_upload_to_cc" do
+    Carambus.config.carambus_api_url = "http://local.test"
+
+    assert_difference("Tournament.count", 1) do
+      post tournaments_url, params: {tournament: {
+        title: "CC-loses Turnier",
+        shortname: "CCL",
+        date: 2.weeks.from_now,
+        end_date: 2.weeks.from_now + 1.day,
+        season_id: 50_000_001,
+        organizer_id: 50_000_001,
+        organizer_type: "Region"
+      }}
+    end
+
+    created = Tournament.order(:id).last
+    assert_redirected_to created
+    assert_equal "CC-loses Turnier", created.title
+    refute created.auto_upload_to_cc, "CC-los angelegte Turniere duerfen nicht automatisch hochgeladen werden"
+  end
+
+  test "POST create re-renders with errors instead of silently redirecting" do
+    Carambus.config.carambus_api_url = "http://local.test"
+
+    assert_no_difference("Tournament.count") do
+      # season fehlt — belongs_to :season ist nicht optional
+      post tournaments_url, params: {tournament: {
+        title: "Turnier ohne Saison",
+        shortname: "TOS",
+        organizer_id: 50_000_001,
+        organizer_type: "Region"
+      }}
+    end
+
+    assert_response :unprocessable_entity,
+      "Validierungsfehler muessen sichtbar werden (vorher: stiller redirect_back)"
+    assert_select "form"
   end
 end

--- a/test/helpers/tournaments_helper_test.rb
+++ b/test/helpers/tournaments_helper_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Plan 26-01: Vereinsauswahl für die Meldeliste eines Region-Turniers.
+# Reihenfolge: Vereine mit gemeldeten Teilnehmern → Austragungsort-Verein → Rest alphabetisch.
+class TournamentsHelperTest < ActionView::TestCase
+  include TournamentsHelper
+
+  setup do
+    @tournament = tournaments(:local)
+    @region = @tournament.organizer
+    assert @region.is_a?(Region), "Fixture-Vorbedingung: Region-Turnier"
+  end
+
+  def club_in_region(name)
+    Club.create!(name: name, shortname: name.gsub(/\s/, "")[0, 8], region_id: @region.id)
+  end
+
+  test "liefert die Vereine der Region alphabetisch, wenn nichts priorisiert ist" do
+    zeta = club_in_region("Zeta Club")
+    alpha = club_in_region("Alpha Club")
+
+    result = entry_list_clubs_for(@tournament)
+    ids = result.map(&:last)
+
+    assert_includes ids, alpha.id
+    assert_includes ids, zeta.id
+    assert_operator ids.index(alpha.id), :<, ids.index(zeta.id), "alphabetisch: Alpha vor Zeta"
+    assert_equal result.map(&:last).uniq, result.map(&:last), "keine Dubletten"
+  end
+
+  test "Verein mit gemeldetem Teilnehmer steht vorn" do
+    _alpha = club_in_region("Alpha Club")
+    zeta = club_in_region("Zeta Club")
+
+    player = Player.create!(lastname: "MUSTER", firstname: "Max", fl_name: "M. Muster")
+    SeasonParticipation.create!(player: player, club: zeta, season: @tournament.season)
+    @tournament.seedings.create!(player_id: player.id, position: 1)
+
+    ids = entry_list_clubs_for(@tournament).map(&:last)
+
+    assert_equal zeta.id, ids.first, "Verein mit Meldung muss vor dem alphabetischen Rest stehen"
+  end
+
+  test "Austragungsort-Verein steht vor dem alphabetischen Rest" do
+    _alpha = club_in_region("Alpha Club")
+    host = club_in_region("Zeta Host Club")
+
+    location = Location.create!(name: "Testhalle 26", organizer: @region)
+    location.clubs << host
+    @tournament.update!(location_id: location.id)
+
+    ids = entry_list_clubs_for(@tournament).map(&:last)
+
+    assert_equal host.id, ids.first, "Austragungsort-Verein muss vorn stehen"
+  end
+
+  test "Meldung schlaegt Austragungsort" do
+    host = club_in_region("Aaa Host Club")
+    seeded = club_in_region("Zzz Seeded Club")
+
+    location = Location.create!(name: "Testhalle 26b", organizer: @region)
+    location.clubs << host
+    @tournament.update!(location_id: location.id)
+
+    player = Player.create!(lastname: "MELDER", firstname: "Mia", fl_name: "M. Melder")
+    SeasonParticipation.create!(player: player, club: seeded, season: @tournament.season)
+    @tournament.seedings.create!(player_id: player.id, position: 1)
+
+    ids = entry_list_clubs_for(@tournament).map(&:last)
+
+    assert_equal seeded.id, ids.first, "Verein mit Meldung vor Austragungsort-Verein"
+    assert_equal host.id, ids.second, "Austragungsort-Verein danach"
+  end
+
+  test "leeres Array, wenn keine Region bestimmbar ist" do
+    club_tournament = Tournament.create!(
+      title: "Club-Turnier 26", season: @tournament.season,
+      organizer: clubs(:bcw), date: Time.current
+    )
+
+    assert_equal [], entry_list_clubs_for(club_tournament)
+  end
+end

--- a/test/models/region_test.rb
+++ b/test/models/region_test.rb
@@ -104,4 +104,38 @@ class RegionTest < ActiveSupport::TestCase
   test "location_row_content: Zeile ohne Link (Kopf/Footer) → nil" do
     assert_nil Region.location_row_content(location_tr("<td>kein Link</td>"))
   end
+
+  # --- Fail-silent-Wächter (Befund 2026-07-21 SBV-Clubs): ScrapeListGuard ---
+
+  def captured_scrape_warnings
+    old_logger = Rails.logger
+    io = StringIO.new
+    Rails.logger = Logger.new(io)
+    yield
+    io.string
+  ensure
+    Rails.logger = old_logger
+  end
+
+  test "warn_if_empty: leere Liste trotz DB-Bestand → warn mit Label und Erwartung" do
+    log = captured_scrape_warnings do
+      assert ScrapeListGuard.warn_if_empty("Clubs SBV", 0, 209)
+    end
+    assert_includes log, "LEERE LISTE Clubs SBV"
+    assert_includes log, "209 in der DB"
+  end
+
+  test "warn_if_empty: leere Liste ohne DB-Bestand → still (Neuanlage ist kein Fehler)" do
+    log = captured_scrape_warnings do
+      refute ScrapeListGuard.warn_if_empty("Clubs XYZ", 0, 0)
+    end
+    refute_includes log, "LEERE LISTE"
+  end
+
+  test "warn_if_empty: nicht-leere Liste → still" do
+    log = captured_scrape_warnings do
+      refute ScrapeListGuard.warn_if_empty("Clubs SBV", 27, 209)
+    end
+    refute_includes log, "LEERE LISTE"
+  end
 end

--- a/test/models/tournament_test.rb
+++ b/test/models/tournament_test.rb
@@ -194,4 +194,38 @@ class TournamentTest < ActiveSupport::TestCase
     )
     assert_nil t.reload.player_class
   end
+  # ---------------------------------------------------------------------------
+  # Plan 27-01: Entwuerfe aus der Saison-Kopie. Kennzeichen liegt im serialisierten data-Hash
+  # (text-Spalte, coder: JSON) — Rohformat verifiziert: {"draft":true,...}
+  # ---------------------------------------------------------------------------
+
+  test "draft? erkennt das Entwurfs-Kennzeichen" do
+    draft = Tournament.create!(title: "Entwurf", season: seasons(:current), organizer: regions(:nbv),
+      date: Time.zone.local(2026, 10, 10), data: {"draft" => true})
+    regular = Tournament.create!(title: "Regulaer", season: seasons(:current), organizer: regions(:nbv),
+      date: Time.zone.local(2026, 10, 11))
+
+    assert draft.draft?
+    refute regular.draft?
+  end
+
+  test "Scopes drafts / without_drafts trennen die Mengen" do
+    draft = Tournament.create!(title: "Entwurf S", season: seasons(:current), organizer: regions(:nbv),
+      date: Time.zone.local(2026, 10, 12), data: {"draft" => true, "copied_from_tournament_id" => 7})
+    regular = Tournament.create!(title: "Regulaer S", season: seasons(:current), organizer: regions(:nbv),
+      date: Time.zone.local(2026, 10, 13), data: {"table_ids" => []})
+
+    assert_includes Tournament.drafts.pluck(:id), draft.id
+    refute_includes Tournament.drafts.pluck(:id), regular.id
+
+    refute_includes Tournament.without_drafts.pluck(:id), draft.id
+    assert_includes Tournament.without_drafts.pluck(:id), regular.id
+  end
+
+  test "without_drafts enthaelt auch Turniere ohne data" do
+    plain = Tournament.create!(title: "Ohne data", season: seasons(:current), organizer: regions(:nbv),
+      date: Time.zone.local(2026, 10, 14))
+
+    assert_includes Tournament.without_drafts.pluck(:id), plain.id
+  end
 end

--- a/test/services/region_server/entry_list_importer_test.rb
+++ b/test/services/region_server/entry_list_importer_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Plan 28-01: Ingest der Meldeliste auf die Authority — mit ID-Uebersetzung.
+# Das Dokument wird direkt injiziert (document:), damit die Tests netzfrei bleiben.
+class RegionServer::EntryListImporterTest < ActiveSupport::TestCase
+  setup do
+    @region = regions(:nbv)
+    @season = seasons(:current)
+    @base_url = "https://nbv.carambus.de"
+    @source_id = 50_000_777 # LOKALE ID der Quelle — darf auf der Authority nirgends auftauchen
+
+    @player = Player.create!(lastname: "GLOBAL", firstname: "Gerd", fl_name: "G. Global", dbu_nr: 777_777)
+  end
+
+  def document(entries: nil, source_tournament_id: @source_id)
+    {
+      "schema" => "carambus.entry_list/v1",
+      "region" => {"shortname" => @region.shortname},
+      "season" => {"name" => @season.name},
+      "tournaments" => [{
+        "source_tournament_id" => source_tournament_id,
+        "title" => "Landesmeisterschaft Dreiband",
+        "shortname" => "LM3B",
+        "balls_goal" => 150,
+        "player_class" => "I",
+        "date" => "2026-10-10T10:00:00+02:00",
+        "end_date" => "2026-10-11T18:00:00+02:00",
+        "entries" => entries || [{
+          "dbu_nr" => 777_777, "lastname" => "GLOBAL", "firstname" => "Gerd",
+          "club" => "Testverein", "position" => 1, "balls_goal" => 150
+        }]
+      }]
+    }
+  end
+
+  def importer(armed: false, doc: document)
+    RegionServer::EntryListImporter.new(
+      region: @region, season: @season, base_url: @base_url, armed: armed, document: doc
+    )
+  end
+
+  test "dry-run schreibt nichts, meldet aber was entstehen wuerde" do
+    result = nil
+    assert_no_difference(["Tournament.count", "Seeding.count"]) do
+      result = importer.call
+    end
+
+    assert_equal 1, result.tournaments_created
+    assert_equal 1, result.seedings_created
+  end
+
+  test "ARMED legt ein Turnier mit GLOBALER id an — die lokale ID taucht nicht auf" do
+    assert_difference("Tournament.count", 1) do
+      importer(armed: true).call
+    end
+
+    imported = Tournament.find_by(source_url: "#{@base_url}/tournaments/#{@source_id}")
+    assert imported, "Turnier muss ueber source_url auffindbar sein"
+    refute_equal @source_id, imported.id, "die lokale Quell-ID darf nicht uebernommen werden"
+    assert_equal "Landesmeisterschaft Dreiband", imported.title
+    assert_equal 150, imported.balls_goal
+    assert_equal @season.id, imported.season_id
+    refute imported.auto_upload_to_cc
+  end
+
+  test "gemeldete Spieler werden als Seedings verknuepft" do
+    importer(armed: true).call
+    imported = Tournament.find_by(source_url: "#{@base_url}/tournaments/#{@source_id}")
+
+    assert_equal 1, imported.seedings.count
+    assert_equal @player.id, imported.seedings.first.player_id
+  end
+
+  test "zweiter Lauf legt keine Dubletten an" do
+    importer(armed: true).call
+
+    result = nil
+    assert_no_difference(["Tournament.count", "Seeding.count"]) do
+      result = importer(armed: true).call
+    end
+    assert_equal 1, result.tournaments_matched
+    assert_equal 0, result.seedings_created
+  end
+
+  test "gewachsene Meldeliste ergaenzt nur den neuen Spieler" do
+    importer(armed: true).call
+    neu = Player.create!(lastname: "NACH", firstname: "Nina", fl_name: "N. Nach", dbu_nr: 888_888)
+
+    erweitert = document(entries: [
+      {"dbu_nr" => 777_777, "lastname" => "GLOBAL", "firstname" => "Gerd", "position" => 1},
+      {"dbu_nr" => 888_888, "lastname" => "NACH", "firstname" => "Nina", "position" => 2}
+    ])
+
+    assert_difference("Seeding.count", 1) do
+      importer(armed: true, doc: erweitert).call
+    end
+
+    imported = Tournament.find_by(source_url: "#{@base_url}/tournaments/#{@source_id}")
+    assert_includes imported.seedings.pluck(:player_id), neu.id
+  end
+
+  test "unaufloesbare Spieler werden berichtet und NICHT angelegt" do
+    unbekannt = document(entries: [
+      {"dbu_nr" => 999_999, "lastname" => "UNBEKANNT", "firstname" => "Udo", "club" => "Fremdverein"}
+    ])
+
+    result = nil
+    assert_no_difference("Player.count") do
+      result = importer(armed: true, doc: unbekannt).call
+    end
+
+    assert_equal 1, result.players_unresolved.size
+    assert_match(/UNBEKANNT/, result.players_unresolved.first)
+    assert_match(/999999|999_999/, result.players_unresolved.first.delete("_"))
+  end
+
+  test "Eintrag ohne Quell-Kennung wird uebersprungen" do
+    ohne_id = document(source_tournament_id: nil)
+
+    result = importer(armed: true, doc: ohne_id).call
+
+    assert_equal 1, result.skipped_no_source_id
+    assert_equal 0, result.tournaments_created
+  end
+
+  test "Antwort ohne tournaments-Liste wird abgelehnt" do
+    assert_raises(ArgumentError) do
+      importer(doc: {"schema" => "carambus.entry_list/v1"}).call
+    end
+  end
+end

--- a/test/services/tournament/season_copier_test.rb
+++ b/test/services/tournament/season_copier_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Plan 27-01: Saison-Kopie der Turnier-STRUKTUR.
+# Leitplanke aus dem CC-Rollover-Incident: niemals Ergebnisse, Seedings oder fremde Provenienz kopieren.
+class Tournament::SeasonCopierTest < ActiveSupport::TestCase
+  setup do
+    @region = regions(:nbv)
+    @from = seasons(:previous)   # 2024/2025
+    @to = seasons(:current)      # 2025/2026
+    @distance = 1
+
+    # Quellturnier mit voller Provenienz, Seedings und Spielen — nichts davon darf mitkommen.
+    @source = Tournament.create!(
+      title: "Landesmeisterschaft Dreiband",
+      shortname: "LM3B",
+      season: @from,
+      organizer: @region,
+      region_id: @region.id,
+      date: Time.zone.local(2024, 10, 12, 10, 0), # Samstag
+      end_date: Time.zone.local(2024, 10, 13, 18, 0),
+      player_class: "I",
+      modus: "kickoff_switches_with_set",
+      balls_goal: 150,
+      innings_goal: 40,
+      ba_id: 987_654,
+      source_url: "https://example.invalid/tournament/1",
+      sync_date: 1.day.ago,
+      ba_state: "finished",
+      state: "results_published"
+    )
+    player = Player.create!(lastname: "TEST", firstname: "Tim", fl_name: "T. Test")
+    @source.seedings.create!(player_id: player.id, position: 1)
+  end
+
+  def copier(armed: false, from: @from, to: @to)
+    Tournament::SeasonCopier.new(region: @region, from_season: from, to_season: to, armed: armed)
+  end
+
+  test "dry-run schreibt nichts, meldet aber was entstehen wuerde" do
+    result = nil
+    assert_no_difference("Tournament.count") do
+      result = copier.call
+    end
+
+    assert_equal 0, result.created
+    assert_equal 1, result.planned.size
+    assert_equal "Landesmeisterschaft Dreiband", result.planned.first[:title]
+  end
+
+  test "ARMED kopiert die Struktur" do
+    assert_difference("Tournament.count", 1) do
+      copier(armed: true).call
+    end
+
+    copy = Tournament.where(season_id: @to.id, organizer: @region).order(:id).last
+    assert_equal @source.title, copy.title
+    assert_equal @source.shortname, copy.shortname
+    assert_equal @source.player_class, copy.player_class
+    assert_equal @source.balls_goal, copy.balls_goal
+    assert_equal @source.innings_goal, copy.innings_goal
+    assert_equal @source.modus, copy.modus
+    assert_equal @to.id, copy.season_id
+  end
+
+  test "Datum wandert um n mal 52 Wochen und behaelt den Wochentag" do
+    copier(armed: true).call
+    copy = Tournament.where(season_id: @to.id, organizer: @region).order(:id).last
+
+    expected = @source.date + (@distance * 52).weeks
+    assert_equal expected.to_date, copy.date.to_date
+    assert_equal @source.date.strftime("%A"), copy.date.strftime("%A"), "Wochentag muss erhalten bleiben"
+    assert_equal (@source.end_date + (@distance * 52).weeks).to_date, copy.end_date.to_date
+  end
+
+  test "Provenienz, Ergebnisse und Laufzeit-Zustand werden NICHT kopiert" do
+    copier(armed: true).call
+    copy = Tournament.where(season_id: @to.id, organizer: @region).order(:id).last
+
+    assert_nil copy.ba_id, "ba_id ist UNIQUE — darf nie mitkopiert werden"
+    assert_nil copy.source_url
+    assert_nil copy.sync_date
+    assert_nil copy.ba_state
+    assert_equal "new_tournament", copy.state
+    assert_equal 0, copy.seedings.count, "Seedings duerfen nicht mitkopiert werden"
+    assert_equal 0, copy.games.count
+    refute copy.auto_upload_to_cc, "CC-los angelegt"
+  end
+
+  test "Kopie ist als Entwurf markiert und kennt ihre Quelle" do
+    copier(armed: true).call
+    copy = Tournament.where(season_id: @to.id, organizer: @region).order(:id).last
+
+    assert_equal true, copy.data["draft"]
+    assert_equal @source.id, copy.data["copied_from_tournament_id"]
+  end
+
+  test "zweiter ARMED-Lauf legt keine Dublette an" do
+    copier(armed: true).call
+
+    result = nil
+    assert_no_difference("Tournament.count") do
+      result = copier(armed: true).call
+    end
+    assert_equal 1, result.skipped_existing
+    assert_equal 0, result.created
+  end
+
+  # Tournament setzt in einem before_save `self.date = Time.at(0) if date.blank?` — ein Turnier
+  # "ohne Datum" traegt also das Epoch-Datum. Genau das muss der Copier als unbrauchbar erkennen.
+  test "Turnier ohne brauchbares Datum (Epoch) wird uebersprungen" do
+    t = Tournament.create!(title: "Ohne Datum", season: @from, organizer: @region, date: nil)
+    assert_equal 1970, t.date.year, "Vorbedingung: before_save setzt Epoch"
+
+    result = copier.call
+
+    assert_equal 1, result.skipped_no_date
+  end
+
+  test "Liga-Turniere bleiben aussen vor" do
+    Tournament.create!(title: "Liga-Sache", season: @from, organizer: @region,
+      date: Time.zone.local(2024, 11, 2, 10, 0), single_or_league: "league")
+
+    result = copier.call
+
+    assert_equal 1, result.planned.size, "nur die Einzelmeisterschaft"
+    refute_includes result.planned.map { |h| h[:title] }, "Liga-Sache"
+  end
+
+  test "Zielsaison vor Quellsaison wird abgelehnt" do
+    assert_raises(ArgumentError) do
+      copier(from: @to, to: @from).call
+    end
+  end
+end


### PR DESCRIPTION
Sammelt die Phase-25..28-Arbeit am CC-losen Turnier-Lebenszyklus plus einen Test-/Fehlerbehandlungs-Fix.

## Enthaltene Commits

- `8c08284e` **feat(25)** — manuellen Turnier-Anlage-Weg im UI reparieren. `_form.html.erb` rief `@tournament.id < MIN_ID` bei `id == nil` (NoMethodError), womit es keinen benutzbaren Anlageweg gab.
- `fae7d8c5` **feat(scrape)** — Warnsignal bei leeren Scrape-Listen (`ScrapeListGuard`), damit fail-silent-Scrapes auffallen.
- `7bf5be1d` **feat(26)** — Meldeliste ohne CC: Teilnehmer über Verein und Spieler melden.
- `cb758f5d` **feat(27)** — Turnier-Vorlage aus Historie: Saison-Struktur als Entwürfe kopieren (`Tournament::SeasonCopier`).
- `a8a88968` **feat(28)** — Meldelisten-Ingest Region Server → Authority (Pull, ID-Übersetzung; `RegionServer::EntryListImporter`, `Api::EntryListsController`).
- `ff91d479` **fix(tournaments)** — siehe unten.
- `ef1acda7` **fix** — festen Zusatzempfänger aus dem Turnier-CSV-Versand entfernen. `write_finale_csv_for_upload` verschickte die Ergebnis-CSV (inkl. Spieler-`cc_id`s) bei jedem Turnierabschluss zusätzlich an eine hartkodierte Adresse; nach Betreiber-Entscheidung entfällt dieser Empfänger ersatzlos, die Mail geht nur noch an `current_admin` und `current_user`.

## Zum letzten Commit

Zwei unabhängige Befunde in `TournamentsController#update`:

**Test-Rot.** Der Test "Sportwart-im-Wirkbereich" war vorbestehend rot. Seit D-38 kommt `sportwart?` aus den expliziten `persona_grants` und nicht mehr aus der Join-Präsenz — `in_sportwart_scope?` lieferte daher sofort `false` und Pundit lehnte die TL-Zuweisung ab, während der Test nur `sportwart_locations`/`-disciplines` setzte. Verdeckt wurde das durch die mehrdeutige Statusprüfung: Erfolgs-Redirect und Deny-Redirect sind beide 302. Der Test schließt den Deny jetzt explizit über `flash[:alert]` aus.

**Stiller Fehler-Schlucker.** Der `rescue StandardError` am Ende von `#update` loggte nur — ohne Render/Redirect antwortete Rails mit **204 No Content**, das Update war für den Nutzer stillschweigend verschwunden. Jetzt `flash.now[:alert]` + `render :edit, status: :unprocessable_entity`, Logging auf `error`-Level, plus `raise if performed?`, damit ein Fehler *nach* erfolgreichem Render nicht als `DoubleRenderError` erneut verdeckt wird. Ein neuer Test pinnt das (provoziert einen echten `NameError` über `organizer_type`, kein Mock nötig — das Projekt hat kein mocha).

## Verifikation

`test/controllers/tournaments_controller_test.rb`: 72 runs, 180 assertions, 0 failures, 0 errors.

Regressionscheck über `test/controllers` + `test/policies` vor/nach dem letzten Commit: 23 → 22 failures bei 47 unveränderten Errors und einem Test mehr. Die verbleibenden Fehlschläge sind vorbestehend und liegen in anderen Dateien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
